### PR TITLE
[Improvement] Clean kern event stream when connection parser make progress

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,6 +1,6 @@
 [submodule "libbpf"]
 	path = libbpf
-	url = https://mirror.ghproxy.com/github.com/libbpf/libbpf.git
+	url = https://github.com/libbpf/libbpf.git
 [submodule "bpftool"]
 	path = bpftool
-	url = https://mirror.ghproxy.com/github.com/libbpf/bpftool
+	url = https://github.com/libbpf/bpftool

--- a/agent/analysis/stat.go
+++ b/agent/analysis/stat.go
@@ -233,6 +233,8 @@ func (s *StatRecorder) ReceiveRecord(r protocol.Record, connection *conn.Connect
 		annotatedRecord.reqNicEventDetails = KernEventsToEventDetails[NicEventDetail](devOutSyscallEvents)
 		annotatedRecord.respNicEventDetails = KernEventsToEventDetails[NicEventDetail](nicIngressEvents)
 	}
+	streamEvents.DiscardEventsBySeq(egressMessage.Seq()+uint64(egressMessage.ByteSize()), true)
+	streamEvents.DiscardEventsBySeq(ingressMessage.Seq()+uint64(ingressMessage.ByteSize()), false)
 	if recordsChannel == nil {
 		log.Infoln(annotatedRecord.String(AnnotatedRecordToStringOptions{
 			Nano: false,

--- a/bpf/types.go
+++ b/bpf/types.go
@@ -9,3 +9,11 @@ type SyscallEventData struct {
 	SyscallEvent SyscallEvent
 	Buf          []byte
 }
+
+func IsEgressStep(step AgentStepT) bool {
+	return step <= AgentStepTNIC_OUT
+}
+
+func IsIngressStep(step AgentStepT) bool {
+	return step >= AgentStepTNIC_IN
+}


### PR DESCRIPTION
**Description:** Clean kern event stream when connection parser make progress

**Related Issues:** [List the issue numbers related to this PR]

**TODO**


**Checklist:**

- [x]  Code has been reviewed
- [x]  Code complies with the project's code standards and best practices
- [x]  Code has passed all tests
- [x]  Code does not affect the normal use of existing features
- [x]  Documentation has been updated

**Screenshots:** [Provide relevant screenshots or GIF animations]