### PR TITLE
[Fix] log warn when remove mem lock failed

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -131,7 +131,7 @@ func SetupAgent(options AgentOptions) {
 
 	// Remove resource limits for kernels <5.11.
 	if err := rlimit.RemoveMemlock(); err != nil {
-		log.Fatal("Remove memlock:", err)
+		log.Warn("Remove memlock:", err)
 	}
 
 	kernelVersion := compatible.GetCurrentKernelVersion()


### PR DESCRIPTION
In centos 3.10, start kyanos encounter error: 
<img width="866" alt="image" src="https://github.com/user-attachments/assets/12405c2a-fd8c-4493-8f71-eb5d8eb95bc5">
