### PR TITLE
[Improvement] Support setting different log levels for different modules.

### DIFF
--- a/agent/agent_utils_test.go
+++ b/agent/agent_utils_test.go
@@ -39,9 +39,8 @@ func StartAgent(bpfAttachFunctions []bpf.AttachBpfProgFunction,
 	wg.Add(1)
 	go func(pid int) {
 		cmd.FilterPid = int64(pid)
-		cmd.Verbose = true
+		cmd.DefaultLogLevel = int32(logrus.DebugLevel)
 		cmd.Debug = true
-		common.Log.SetLevel(logrus.DebugLevel)
 		agent.SetupAgent(agent.AgentOptions{
 			Stopper: agentStopper,
 			LoadBpfProgramFunction: func(objs interface{}) *list.List {

--- a/agent/analysis/analysis.go
+++ b/agent/analysis/analysis.go
@@ -2,6 +2,7 @@ package analysis
 
 import (
 	"cmp"
+	ac "kyanos/agent/common"
 	"kyanos/agent/protocol"
 	"kyanos/common"
 	"math"
@@ -124,7 +125,7 @@ type Analyzer struct {
 
 func CreateAnalyzer(recordsChannel <-chan *AnnotatedRecord, showOption *AnalysisOptions, resultChannel chan<- []*ConnStat, renderStopper chan int) *Analyzer {
 	stopper := make(chan int)
-	common.AddToFastStopper(stopper)
+	ac.AddToFastStopper(stopper)
 	analyzer := &Analyzer{
 		Classfier:       getClassfier(showOption.ClassfierType),
 		recordsChannel:  recordsChannel,
@@ -190,6 +191,6 @@ func (a *Analyzer) analyze(record *AnnotatedRecord) {
 		}
 		aggregator.receive(record)
 	} else {
-		log.Errorf("classify error: %v\n", err)
+		common.DefaultLog.Warnf("classify error: %v\n", err)
 	}
 }

--- a/agent/analysis/stat.go
+++ b/agent/analysis/stat.go
@@ -11,7 +11,7 @@ import (
 	"github.com/jefurry/logrus"
 )
 
-var log *logrus.Logger = common.Log
+var outputLog *logrus.Logger = logrus.New()
 
 type StatRecorder struct {
 }
@@ -244,7 +244,7 @@ func (s *StatRecorder) ReceiveRecord(r protocol.Record, connection *conn.Connect
 	streamEvents.DiscardEventsBySeq(egressMessage.Seq()+uint64(egressMessage.ByteSize()), true)
 	streamEvents.DiscardEventsBySeq(ingressMessage.Seq()+uint64(ingressMessage.ByteSize()), false)
 	if recordsChannel == nil {
-		log.Infoln(annotatedRecord.String(AnnotatedRecordToStringOptions{
+		outputLog.Infoln(annotatedRecord.String(AnnotatedRecordToStringOptions{
 			Nano: false,
 			MetricTypeSet: MetricTypeSet{
 				ResponseSize:                 false,

--- a/agent/common/stopper.go
+++ b/agent/common/stopper.go
@@ -1,6 +1,9 @@
 package common
 
-import "time"
+import (
+	"kyanos/common"
+	"time"
+)
 
 var faststoppers *[]chan int
 var slowstoppers *[]chan int
@@ -14,13 +17,20 @@ func AddToSlowStopper(c chan int) {
 }
 
 func SendStopSignal() {
-	Log.Debugf("%d fast stoppers needs to be signal\n", len(*faststoppers))
+	common.AgentLog.Debugf("%d fast stoppers needs to be signal\n", len(*faststoppers))
 	for _, s := range *faststoppers {
 		s <- 1
 	}
 	time.Sleep(500 * time.Millisecond)
-	Log.Debugf("%d slow stoppers needs to be signal\n", len(*slowstoppers))
+	common.AgentLog.Debugf("%d slow stoppers needs to be signal\n", len(*slowstoppers))
 	for _, s := range *slowstoppers {
 		s <- 1
 	}
+}
+
+func init() {
+	_stoppers1 := make([]chan int, 0)
+	faststoppers = &_stoppers1
+	_stoppers2 := make([]chan int, 0)
+	slowstoppers = &_stoppers2
 }

--- a/agent/compatible/type.go
+++ b/agent/compatible/type.go
@@ -2,6 +2,7 @@ package compatible
 
 import (
 	"cmp"
+	"fmt"
 	"kyanos/bpf"
 	"kyanos/common"
 	"slices"
@@ -10,7 +11,7 @@ import (
 	"github.com/emirpasic/gods/maps/treemap"
 )
 
-var log = common.Log
+var log = common.DefaultLog
 
 type Capability int
 
@@ -88,7 +89,7 @@ func GetBestMatchedKernelVersion(version string) KernelVersion {
 			log.Debugf("Can't find version: %s, use the smallest version current supported: %s", version, foundKey)
 			return foundValue.(KernelVersion)
 		} else {
-			log.Fatalln("Initialize error!")
+			log.Fatalln(fmt.Sprintf("kernel version: %s is too old, currently not suppport", version))
 			return KernelVersion{}
 		}
 	} else {

--- a/agent/conn/kern_event_handler.go
+++ b/agent/conn/kern_event_handler.go
@@ -4,6 +4,7 @@ import (
 	"cmp"
 	"fmt"
 	"kyanos/bpf"
+	"kyanos/common"
 	"kyanos/monitor"
 	"slices"
 )
@@ -49,7 +50,7 @@ func (s *KernEventStream) AddKernEvent(event *bpf.AgentKernEvt) {
 			step:      event.Step,
 		})
 		if len(kernEvtSlice) > s.maxLen {
-			log.Debugf("kern event stream size: %d exceed maxLen", len(kernEvtSlice))
+			common.ConntrackLog.Debugf("kern event stream size: %d exceed maxLen", len(kernEvtSlice))
 		}
 		for len(kernEvtSlice) > s.maxLen {
 			kernEvtSlice = kernEvtSlice[1:]

--- a/agent/protocol/common.go
+++ b/agent/protocol/common.go
@@ -2,12 +2,7 @@ package protocol
 
 import (
 	"kyanos/agent/buffer"
-	"kyanos/common"
-
-	"github.com/jefurry/logrus"
 )
-
-var log *logrus.Logger = common.Log
 
 func matchByTimestamp(reqStream *[]ParsedMessage, respStream *[]ParsedMessage) []Record {
 	if len(*reqStream) == 0 || len(*respStream) == 0 {

--- a/agent/protocol/http.go
+++ b/agent/protocol/http.go
@@ -246,7 +246,7 @@ func (filter HttpFilter) FilterByResponse() bool {
 func (filter HttpFilter) Filter(parsedReq ParsedMessage, parsedResp ParsedMessage) bool {
 	req, ok := parsedReq.(*ParsedHttpRequest)
 	if !ok {
-		log.Warnf("[HttpFilter] cast to http.Request failed: %v\n", req)
+		common.ProtocolParserLog.Warnf("[HttpFilter] cast to http.Request failed: %v\n", req)
 		return false
 	}
 

--- a/agent/protocol/mysql/mysql.go
+++ b/agent/protocol/mysql/mysql.go
@@ -93,10 +93,10 @@ func (m *MysqlParser) Match(reqStream *[]ParsedMessage, respStream *[]ParsedMess
 			isLastSeq := len(*reqStream) == 1
 			respLooksHealthy := len(respPacketsView) == len(*respStream)
 			if isLastSeq && respLooksHealthy {
-				common.Log.Debugln("Appears to be an incomplete message. Waiting for more data")
+				common.ProtocolParserLog.Debugln("Appears to be an incomplete message. Waiting for more data")
 				break
 			}
-			common.Log.Debugf("Didn't have enough response packets, but doesn't appear to be partial either. "+
+			common.ProtocolParserLog.Debugf("Didn't have enough response packets, but doesn't appear to be partial either. "+
 				"[cmd=%v, cmd_msg=%s resp_packets=%d]", command, reqPacket.msg[1:], len(respPacketsView))
 		} else if state == Success {
 			records = append(records, record)
@@ -127,7 +127,7 @@ func getRespView(reqStream *[]ParsedMessage, respStream *[]ParsedMessage) []Pars
 		respPacket := resp.(*MysqlPacket)
 		expectedSeqId := count + 1
 		if respPacket.seqId != byte(expectedSeqId) {
-			common.Log.Infof("Found packet with unexpected sequence ID [expected=%d actual=%d]",
+			common.ProtocolParserLog.Infof("Found packet with unexpected sequence ID [expected=%d actual=%d]",
 				expectedSeqId,
 				respPacket.seqId)
 			break
@@ -218,11 +218,11 @@ func (p *MysqlParser) processPackets(reqPacket *MysqlPacket, respView []ParsedMe
 	case kTableDump:
 		fallthrough
 	case kStatistics:
-		common.Log.Warnf("Unimplemented command %d.\n", command)
+		common.ProtocolParserLog.Warnf("Unimplemented command %d.\n", command)
 		parseState = Ignore
 		return record, parseState
 	default:
-		common.Log.Warnf("Unknown command %d.\n", command)
+		common.ProtocolParserLog.Warnf("Unknown command %d.\n", command)
 		parseState = Ignore
 		return record, parseState
 	}

--- a/agent/protocol/mysql/utils.go
+++ b/agent/protocol/mysql/utils.go
@@ -58,7 +58,7 @@ func isOkPacket(packet *MysqlPacket) bool {
 	}
 
 	if warnings > 1000 {
-		common.Log.Warnln("Large warnings count is a sign of misclassification of OK packet.")
+		common.ProtocolParserLog.Warnln("Large warnings count is a sign of misclassification of OK packet.")
 	}
 
 	// 7 byte minimum packet size in protocol 4.1.
@@ -78,14 +78,14 @@ func isStmtPrepareOKPacket(packet *MysqlPacket) bool {
 
 func DissectDateTimeParam(msg string, offset *int, param *string) bool {
 	if len(msg) < *offset+1 {
-		common.Log.Warnln("Not enough bytes to dissect date/time param.")
+		common.ProtocolParserLog.Warnln("Not enough bytes to dissect date/time param.")
 		return false
 	}
 
 	length := msg[*offset]
 	*offset = *offset + 1
 	if len(msg) < *offset+int(length) {
-		common.Log.Warnln("Not enough bytes to dissect date/time param.")
+		common.ProtocolParserLog.Warnln("Not enough bytes to dissect date/time param.")
 		return false
 	}
 	*param = "MySQL DateTime rendering not implemented yet"
@@ -97,7 +97,7 @@ func DissectFloatParam[T common.KFloat](msg string, offset *int, params *string)
 	var t T
 	length := int(unsafe.Sizeof(t))
 	if len(msg) < *offset+length {
-		common.Log.Warnln("Not enough bytes to dissect float param.")
+		common.ProtocolParserLog.Warnln("Not enough bytes to dissect float param.")
 		return false
 	}
 	*params = fmt.Sprintf("%f", common.LEndianBytesToFloat[T]([]byte(msg[*offset:*offset+length])))
@@ -114,7 +114,7 @@ func DissectIntParam[T common.KInt](s string, offset *int, nbytes uint, param *s
 
 func DissectInt[T common.KInt](msg string, offset *int, length int, result *T) bool {
 	if len(msg) < *offset+length {
-		common.Log.Errorln("Not enough bytes to dissect int param.")
+		common.ProtocolParserLog.Errorln("Not enough bytes to dissect int param.")
 		return false
 	}
 	*result, _ = common.LEndianBytesToKInt[T]([]byte(msg[*offset:]), length)
@@ -217,7 +217,7 @@ func MoreResultsExist(packet *MysqlPacket) bool {
 		_, ok1 := processLengthEncodedInt(packet.msg, &pos)
 		_, ok2 := processLengthEncodedInt(packet.msg, &pos)
 		if !ok1 || !ok2 {
-			common.Log.Warnln("Error parsing OK packet for SERVER_MORE_RESULTS_EXIST_FLAG")
+			common.ProtocolParserLog.Warnln("Error parsing OK packet for SERVER_MORE_RESULTS_EXIST_FLAG")
 			return false
 		}
 		return int8(packet.msg[pos])&kServerMoreResultsExistFlag != 0

--- a/agent/protocol/redis..go
+++ b/agent/protocol/redis..go
@@ -605,7 +605,7 @@ func extractKeyFromPayLoad(redisMessage *RedisMessage) string {
 func (r RedisFilter) Filter(req ParsedMessage, resp ParsedMessage) bool {
 	redisReq, ok := req.(*RedisMessage)
 	if !ok {
-		log.Warnf("[RedisFilter] cast to RedisMessage failed: %v\n", req)
+		common.ProtocolParserLog.Warnf("[RedisFilter] cast to RedisMessage failed: %v\n", req)
 		return false
 	}
 	pass := true

--- a/agent/render/render.go
+++ b/agent/render/render.go
@@ -8,9 +8,11 @@ import (
 	"kyanos/common"
 	"slices"
 	"time"
+
+	"github.com/jefurry/logrus"
 )
 
-var log = common.Log
+var log *logrus.Logger = logrus.New()
 
 type RenderOptions struct {
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -4,16 +4,13 @@ import (
 	"fmt"
 	"kyanos/agent"
 	"kyanos/common"
-	"os"
-	"time"
 
 	"github.com/jefurry/logrus"
-	"github.com/jefurry/logrus/hooks/rotatelog"
 	"github.com/spf13/cobra"
 	"github.com/spf13/viper"
 )
 
-var logger *logrus.Logger = common.Log
+var logger *logrus.Logger = common.DefaultLog
 
 var rootCmd = &cobra.Command{
 	Use:   "kyanos <command> [<args>]",
@@ -27,7 +24,7 @@ var rootCmd = &cobra.Command{
 }
 
 // var LogDir string
-var Verbose bool
+// var Verbose bool
 var Daemon bool
 var Debug bool
 var FilterPid int64
@@ -40,6 +37,11 @@ var BTFFilePath string
 var BPFVerifyLogSize int
 var KernEvtPerfEventBufferSize int
 var DataEvtPerfEventBufferSize int
+var DefaultLogLevel int32
+var AgentLogLevel int32
+var BPFEventLogLevel int32
+var ConntrackLogLevel int32
+var ProtocolLogLevel int32
 
 func init() {
 	// rootCmd.PersistentFlags().StringVar(&LogDir, "log-dir", "", "log file dir")
@@ -48,14 +50,21 @@ func init() {
 	rootCmd.PersistentFlags().StringSliceVarP(&RemotePorts, common.RemotePortsVarName, "", []string{}, "specify remote ports to trace, default trace all")
 	rootCmd.PersistentFlags().StringSliceVarP(&LocalPorts, common.LocalPortsVarName, "", []string{}, "specify local ports to trace, default trace all")
 	rootCmd.PersistentFlags().StringSliceVarP(&RemoteIps, common.RemoteIpsVarName, "", []string{}, "specify remote ips to trace, default trace all")
-	rootCmd.PersistentFlags().BoolVarP(&Debug, "debug", "d", false, "print more logs helpful to debug")
-	rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "print verbose message")
+	// rootCmd.PersistentFlags().BoolVarP(&Verbose, "verbose", "v", false, "print verbose message")
 	rootCmd.PersistentFlags().StringVar(&IfName, "ifname", "eth0", "--ifname eth0")
 	rootCmd.PersistentFlags().MarkHidden("compatible")
 	rootCmd.PersistentFlags().StringVar(&BTFFilePath, "btf", "", "btf file path")
 	rootCmd.PersistentFlags().IntVar(&BPFVerifyLogSize, "bpf-verify-log-size", 1*1024*1024, "--bpf-verify-log-size 1024")
 	rootCmd.PersistentFlags().IntVar(&KernEvtPerfEventBufferSize, "kern-perf-event-buffer-size", 1*1024*1024, "--kern-perf-event-buffer-size 1024")
 	rootCmd.PersistentFlags().IntVar(&KernEvtPerfEventBufferSize, "data-perf-event-buffer-size", 30*1024*1024, "--data-perf-event-buffer-size 1024")
+
+	// log config
+	rootCmd.PersistentFlags().BoolVarP(&Debug, "debug", "d", false, "print more logs helpful to debug")
+	rootCmd.PersistentFlags().Int32Var(&DefaultLogLevel, "default-log-level", 3, "--default-log-level 4 # specify default log level, from 1(fatal level) to 5(debug level)")
+	rootCmd.PersistentFlags().Int32Var(&AgentLogLevel, "agent-log-level", 0, "--agent-log-level 4 # specify agent module log level individually")
+	rootCmd.PersistentFlags().Int32Var(&BPFEventLogLevel, "bpf-event-log-level", 0, "--bpf-event-log-level 4 # specify bpf event log level individually")
+	rootCmd.PersistentFlags().Int32Var(&ConntrackLogLevel, "conntrack-log-level", 0, "--conntrack-log-level 4 # specify conntrack module log level individually")
+	rootCmd.PersistentFlags().Int32Var(&ProtocolLogLevel, "protocol-log-level", 0, "--protocol-log-level 4 # specify protocol module log level individually")
 	rootCmd.Flags().SortFlags = false
 	rootCmd.PersistentFlags().SortFlags = false
 	viper.BindPFlags(rootCmd.Flags())
@@ -65,26 +74,5 @@ func init() {
 func Execute() {
 	if err := rootCmd.Execute(); err != nil {
 		fmt.Println(err)
-	}
-}
-
-func initLog() {
-	if viper.GetBool(common.VerboseVarName) {
-		logger.SetLevel(logrus.DebugLevel)
-	} else {
-		logger.SetLevel(logrus.InfoLevel)
-	}
-	logger.SetOut(os.Stdout)
-
-	logdir := viper.GetString(common.LogDirVarName)
-	if logdir != "" {
-		hook, err := rotatelog.NewHook(
-			logdir+"/kyanos.log.%Y%m%d",
-			rotatelog.WithMaxAge(time.Hour*24),
-			rotatelog.WithRotationTime(time.Hour),
-		)
-		if err == nil {
-			logger.Hooks.Add(hook)
-		}
 	}
 }

--- a/common/constant.go
+++ b/common/constant.go
@@ -1,14 +1,9 @@
 package common
 
-import (
-	"github.com/jefurry/logrus"
-)
-
-var Log *logrus.Logger = logrus.New()
-
 var CollectorAddrVarName string = "collector-addr"
 var LocalModeVarName string = "local-mode"
-var VerboseVarName string = "verbose"
+
+// var VerboseVarName string = "verbose"
 var DaemonVarName string = "daemon"
 var LogDirVarName string = "log-dir"
 var FilterPidVarName string = "pid"

--- a/common/log.go
+++ b/common/log.go
@@ -1,0 +1,10 @@
+package common
+
+import "github.com/jefurry/logrus"
+
+var DefaultLog *logrus.Logger = logrus.New()
+var AgentLog *logrus.Logger = logrus.New()
+
+var BPFEventLog *logrus.Logger = logrus.New()
+var ConntrackLog *logrus.Logger = logrus.New()
+var ProtocolParserLog *logrus.Logger = logrus.New()

--- a/common/type.go
+++ b/common/type.go
@@ -46,10 +46,3 @@ func (c *ConnDesc) String() string {
 	}
 	return fmt.Sprintf("[pid=%d][protocol=%d] *%s:%d %s %s:%d", c.Pid, c.Protocol, c.LocalAddr.String(), c.LocalPort, direct, c.RemoteAddr.String(), c.RemotePort)
 }
-
-func init() {
-	_stoppers1 := make([]chan int, 0)
-	faststoppers = &_stoppers1
-	_stoppers2 := make([]chan int, 0)
-	slowstoppers = &_stoppers2
-}

--- a/common/utils.go
+++ b/common/utils.go
@@ -194,11 +194,11 @@ func GetKernelVersion() *version.Version {
 	release := si.Kernel.Release
 	v, err := version.NewVersion(release)
 	if err != nil {
-		Log.Debugf("Parse kernel version failed: %v, may be centos version, adjust and retry", err)
+		DefaultLog.Debugf("Parse kernel version failed: %v, may be centos version, adjust and retry", err)
 		release = release[:strings.Index(release, "-")]
 		v, err = version.NewVersion(release)
 		if err != nil {
-			Log.Fatalf("Can't parse kernel version: %v, may be a bug, please submit a issue on http://github.com/hengyoush/kyanos", err)
+			DefaultLog.Fatalf("Can't parse kernel version: %v, may be a bug, please submit a issue on http://github.com/hengyoush/kyanos", err)
 		} else {
 			return v
 		}
@@ -217,13 +217,3 @@ func TruncateString(s string, maxBytes int) string {
 		return fmt.Sprintf("%s...(truncated, total: %dbytes)", s[:maxBytes], len(s))
 	}
 }
-
-// func EnabledXdp() bool {
-// 	return !NeedsRunningInCompatibleMode()
-// }
-
-// func NeedsRunningInCompatibleMode() bool {
-// 	kernel58, _ := version.NewVersion("5.8")
-// 	curKernelVersion := GetKernelVersion()
-// 	return viper.GetBool("compatible") || curKernelVersion == nil || curKernelVersion.LessThan(kernel58)
-// }

--- a/monitor/monitor.go
+++ b/monitor/monitor.go
@@ -8,7 +8,7 @@ import (
 	"time"
 )
 
-var log = common.Log
+var log = common.DefaultLog
 
 var enableMonitor = false
 


### PR DESCRIPTION
Add log level options to cmd:
```
      --default-log-level int32           --default-log-level 4 # specify default log level, from 1(fatal level) to 5(debug level) (default 3)
      --agent-log-level int32             --agent-log-level 4 # specify agent module log level individually
      --bpf-event-log-level int32         --bpf-event-log-level 4 # specify bpf event log level individually
      --conntrack-log-level int32         --conntrack-log-level 4 # specify conntrack module log level individually
      --protocol-log-level int32          --protocol-log-level 4 # specify protocol module log level individually
```