### PR TITLE
fix(conntrack): fix Connection4 OnClose func bug

### DIFF
--- a/agent/conn/conntrack.go
+++ b/agent/conn/conntrack.go
@@ -228,8 +228,9 @@ func (c *Connection4) OnClose(needClearBpfMap bool) {
 	OnCloseRecordFunc(c)
 	c.Status = Closed
 	if needClearBpfMap {
-		connInfoMap := bpf.GetMapFromObjs(bpf.Objs, "ConnInfoMap")
-		err := connInfoMap.Delete(c.TgidFd)
+		var err error
+		// connInfoMap := bpf.GetMapFromObjs(bpf.Objs, "ConnInfoMap")
+		// err = connInfoMap.Delete(c.TgidFd)
 		key, revKey := c.extractSockKeys()
 		sockKeyConnIdMap := bpf.GetMapFromObjs(bpf.Objs, "SockKeyConnIdMap")
 		err = sockKeyConnIdMap.Delete(key)


### PR DESCRIPTION
when Connection4 Onclose() be called, donot delete conn_info_map entry, because it may be other connection with same tgid but different ipport.