### PR TITLE
Add pragma to ignore int conversion warning in pktlatency.h

### DIFF
--- a/bpf/pktlatency.h
+++ b/bpf/pktlatency.h
@@ -1,3 +1,5 @@
+_Pragma("GCC diagnostic ignored \"-Wint-conversion\"")
+
 #ifndef __KPROBE_H__
 #define __KPROBE_H__
 


### PR DESCRIPTION
I couldn't compile the latest code without adding this.

Otherwise I got the error:

incompatible integer to pointer conversion assigning to 'struct socket *' from '__u64' (aka 'unsigned long long') 