### PR TITLE
feat: Print osinfo when start failed

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -144,7 +144,6 @@ func SetupAgent(options ac.AgentOptions) {
 	}
 	if _bf.Err != nil {
 		logSystemInfo(_bf.Err)
-		common.AgentLog.Error("Failed to load BPF: ", _bf.Err)
 		return
 	}
 

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -205,10 +205,11 @@ func logSystemInfo(loadError error) {
 ============OS Info================
 %s
 ===================================
-Please visit https://github.com/kyanos/issues to report this issue.
-
+FAQ         : https://kyanos.io/faq.html
+Submit issue: https://github.com/hengyoush/kyanos/issues
 
 `
+
 	var errorInfo string
 	if loadError != nil {
 		errorInfo = "Error: " + loadError.Error()


### PR DESCRIPTION
Add system info logging for crash reports

- Implemented a function to log system information when a crash occurs.
- The function collects OS, architecture, CPU count, Go version, kernel version, and Linux distribution details.
- Added formatted crash report output including error messages and system information.
- Included instructions for reporting issues on GitHub.

---

like this :
```bash
===================================
          Kyanos Crash Report
=========Error Message=============
Error: !23
============OS Info================
OS: linux
Arch: amd64
NumCPU: 2
GoVersion: go1.23.3
Kernel Version: 5.15.0-72-generic
PRETTY_NAME="Ubuntu 22.04 LTS"
NAME="Ubuntu"
VERSION_ID="22.04"
VERSION="22.04 (Jammy Jellyfish)"
VERSION_CODENAME=jammy
ID=ubuntu
ID_LIKE=debian
HOME_URL="https://www.ubuntu.com/"
SUPPORT_URL="https://help.ubuntu.com/"
BUG_REPORT_URL="https://bugs.launchpad.net/ubuntu/"
PRIVACY_POLICY_URL="https://www.ubuntu.com/legal/terms-and-policies/privacy-policy"
UBUNTU_CODENAME=jammy
===================================
Please visit https://github.com/kyanos/issues to report this issue.


```