### PR TITLE
docs: wrong url to download the init script

### DIFF
--- a/COMPILATION.md
+++ b/COMPILATION.md
@@ -12,7 +12,7 @@ This document describes the local compilation method for kyanos. My environment 
 ### Ubuntu
 If you are using Ubuntu 20.04 or later, you can initialize the compilation environment with a single command.
 ```
-/bin/bash -c "$(curl -fsSL https://github.com/hengyoush/kyanos/blob/main/init_env.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/hengyoush/kyanos/refs/heads/main/init_env.sh)"
 ```
 ### Other Linux Distributions
 clone the project (don't forget to update submodle!):

--- a/COMPILATION_CN.md
+++ b/COMPILATION_CN.md
@@ -12,7 +12,7 @@
 ### Ubuntu
 如果你使用的是ubuntu 20.04以及更新版本，可以使用一条命令即可完成编译环境的初始化。
 ```
-/bin/bash -c "$(curl -fsSL https://github.com/hengyoush/kyanos/blob/main/init_env.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/hengyoush/kyanos/refs/heads/main/init_env.sh)"
 ```
 ### 其他 Linux 发行版
 用下面的命令 clone 项目:

--- a/docs/cn/how-to-build.md
+++ b/docs/cn/how-to-build.md
@@ -17,7 +17,7 @@ prev: false
 ### Ubuntu
 如果你使用的是 ubuntu 20.04 以及更新版本，可以使用一条命令即可完成编译环境的初始化。
 ```
-/bin/bash -c "$(curl -fsSL https://github.com/hengyoush/kyanos/blob/main/init_env.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/hengyoush/kyanos/refs/heads/main/init_env.sh)"
 ```
 ### 其他 Linux 发行版
 用下面的命令 clone 项目:

--- a/docs/how-to-build.md
+++ b/docs/how-to-build.md
@@ -16,7 +16,7 @@ This document describes the local compilation method for kyanos. My environment 
 ### Ubuntu
 If you are using Ubuntu 22.04 or later, you can initialize the compilation environment with a single command.
 ```
-/bin/bash -c "$(curl -fsSL https://github.com/hengyoush/kyanos/blob/main/init_env.sh)"
+/bin/bash -c "$(curl -fsSL https://raw.githubusercontent.com/hengyoush/kyanos/refs/heads/main/init_env.sh)"
 ```
 ### Other Linux Distributions
 clone the project (don't forget to update submodle!):


### PR DESCRIPTION
Previous URL is a GitHub website, not raw content.

![image](https://github.com/user-attachments/assets/8a6eebb3-e31d-4861-8999-1d3a9aa7b433)

Correct URL:

![image](https://github.com/user-attachments/assets/2a163d44-dff4-4ed4-bd47-469f4dbed7d9)
 