### PR TITLE
fix(stat): elapsed time is negative

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -68,7 +68,7 @@ func SetupAgent(options ac.AgentOptions) {
 	var recordsChannel chan *anc.AnnotatedRecord = nil
 	recordsChannel = make(chan *anc.AnnotatedRecord, 1000)
 
-	pm := conn.InitProcessorManager(options.ProcessorsNum, connManager, options.MessageFilter, options.LatencyFilter, options.SizeFilter, options.TraceSide)
+	pm := conn.InitProcessorManager(options.ProcessorsNum, connManager, options.MessageFilter, options.LatencyFilter, options.SizeFilter, options.TraceSide, options.ConntrackCloseWaitTimeMills)
 	conn.RecordFunc = func(r protocol.Record, c *conn.Connection4) error {
 		return statRecorder.ReceiveRecord(r, c, recordsChannel)
 	}

--- a/agent/common/options.go
+++ b/agent/common/options.go
@@ -47,6 +47,7 @@ type AgentOptions struct {
 	DisableOpensslUprobe        bool
 	WatchOptions                watch.WatchOptions
 	PerformanceMode             bool
+	ConntrackCloseWaitTimeMills int
 
 	FilterComm              string
 	ProcessExecEventChannel chan *bpf.AgentProcessExecEvent

--- a/agent/render/watch/watch_render.go
+++ b/agent/render/watch/watch_render.go
@@ -79,6 +79,9 @@ var (
 			}
 		},
 		data: func(r *common.AnnotatedRecord) string {
+			if r.TotalDuration == -1 {
+				return "-"
+			}
 			return fmt.Sprintf("%.2f", c.ConvertDurationToMillisecondsIfNeeded(r.TotalDuration, false))
 		},
 		width:      10,
@@ -132,6 +135,9 @@ var (
 			}
 		},
 		data: func(r *common.AnnotatedRecord) string {
+			if r.BlackBoxDuration == -1 {
+				return "-"
+			}
 			return fmt.Sprintf("%.2f", c.ConvertDurationToMillisecondsIfNeeded(r.BlackBoxDuration, false))
 		},
 		width:      13,
@@ -147,6 +153,9 @@ var (
 			}
 		},
 		data: func(r *common.AnnotatedRecord) string {
+			if r.ReadFromSocketBufferDuration == -1 {
+				return "-"
+			}
 			return fmt.Sprintf("%.2f", c.ConvertDurationToMillisecondsIfNeeded(r.ReadFromSocketBufferDuration, false))
 		},
 		width:      15,

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -94,6 +94,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&options.PerformanceMode, "performance-mode", true, "--performance false")
 	rootCmd.PersistentFlags().IntVar(&KernEvtPerfEventBufferSize, "kern-perf-event-buffer-size", 1*1024*1024, "--kern-perf-event-buffer-size 1024")
 	rootCmd.PersistentFlags().IntVar(&KernEvtPerfEventBufferSize, "data-perf-event-buffer-size", 30*1024*1024, "--data-perf-event-buffer-size 1024")
+	rootCmd.PersistentFlags().IntVar(&options.ConntrackCloseWaitTimeMills, "conntrack-close-wait-time-mills", 100, "--conntrack-close-wait-time-mills 100")
 
 	rootCmd.PersistentFlags().MarkHidden("default-log-level")
 	rootCmd.PersistentFlags().MarkHidden("agent-log-level")
@@ -104,6 +105,7 @@ func init() {
 	rootCmd.PersistentFlags().MarkHidden("kern-perf-event-buffer-size")
 	rootCmd.PersistentFlags().MarkHidden("data-perf-event-buffer-size")
 	rootCmd.PersistentFlags().MarkHidden("performance-mode")
+	rootCmd.PersistentFlags().MarkHidden("conntrack-close-wait-time-mills")
 
 	rootCmd.Flags().SortFlags = false
 	rootCmd.PersistentFlags().SortFlags = false


### PR DESCRIPTION
Introduce a new option `conntrack-close-wait-time-mills` which control how long time before a `Connection4` turn into `closed` state. If too long, new connection with same tgidfd 's data may come into old connection  event stream or syscall data buffer, cause negative time. Set it  to a relatively small value  will prevent  this situation. (change 1s to 100ms(default))