### PR TITLE
fix: use tracepoint instead of kprobe to trace skb_copy_datagram_iovec

### DIFF
--- a/agent/compatible/type.go
+++ b/agent/compatible/type.go
@@ -112,7 +112,7 @@ func init() {
 			bpf.AgentStepTDEV_IN:    {InstrumentFunction{"tracepoint/net/netif_receive_skb", "TracepointNetifReceiveSkb"}},
 			bpf.AgentStepTIP_IN:     {InstrumentFunction{"kprobe/ip_rcv_core", "IpRcvCore"}},
 			bpf.AgentStepTTCP_IN:    {InstrumentFunction{"kprobe/tcp_v4_do_rcv", "TcpV4DoRcv"}},
-			bpf.AgentStepTUSER_COPY: {InstrumentFunction{"kprobe/__skb_datagram_iter", "SkbCopyDatagramIter"}},
+			bpf.AgentStepTUSER_COPY: {InstrumentFunction{"tracepoint/skb/skb_copy_datagram_iovec", "TracepointSkbCopyDatagramIovec"}},
 		},
 		Capabilities: map[Capability]bool{
 			SupportConstants:         true,
@@ -140,8 +140,6 @@ func init() {
 	v4d14.addBackupInstrumentFunction(bpf.AgentStepTIP_OUT, InstrumentFunction{"kprobe/__ip_queue_xmit", "IpQueueXmit"})
 	v4d14.InstrumentFunctions[bpf.AgentStepTIP_IN] =
 		[]InstrumentFunction{{"kprobe/ip_rcv", "IpRcvCore"}}
-	v4d14.InstrumentFunctions[bpf.AgentStepTUSER_COPY] =
-		[]InstrumentFunction{{"kprobe/skb_copy_datagram_iter", "SkbCopyDatagramIter"}}
 	v4d14.removeCapability(SupportConstants).removeCapability(SupportRawTracepoint).removeCapability(SupportBTF).removeCapability(SupportXDP)
 	KernelVersionsMap.Put(v4d14.Version, v4d14)
 
@@ -149,8 +147,6 @@ func init() {
 	v310.Version = "3.10.0"
 	v310.InstrumentFunctions[bpf.AgentStepTIP_OUT] =
 		[]InstrumentFunction{{"kprobe/ip_queue_xmit", "IpQueueXmit2"}}
-	v310.InstrumentFunctions[bpf.AgentStepTUSER_COPY] =
-		[]InstrumentFunction{{"kprobe/skb_copy_datagram_iovec", "SkbCopyDatagramIter"}}
 	v310.addBackupInstrumentFunction(bpf.AgentStepTIP_IN, InstrumentFunction{"kprobe/ip_rcv", "IpRcvCore"})
 	v310.removeCapability(SupportConstants).
 		removeCapability(SupportRawTracepoint).

--- a/bpf/agent_arm64_bpfel.go
+++ b/bpf/agent_arm64_bpfel.go
@@ -276,6 +276,7 @@ type AgentProgramSpecs struct {
 	TracepointNetifReceiveSkb            *ebpf.ProgramSpec `ebpf:"tracepoint__netif_receive_skb"`
 	TracepointSchedSchedProcessExec      *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit      *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
+	TracepointSkbCopyDatagramIovec       *ebpf.ProgramSpec `ebpf:"tracepoint__skb_copy_datagram_iovec"`
 	TracepointSyscallsSysEnterAccept4    *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_accept4"`
 	TracepointSyscallsSysEnterClose      *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_close"`
 	TracepointSyscallsSysEnterConnect    *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_connect"`
@@ -461,6 +462,7 @@ type AgentPrograms struct {
 	TracepointNetifReceiveSkb            *ebpf.Program `ebpf:"tracepoint__netif_receive_skb"`
 	TracepointSchedSchedProcessExec      *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit      *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
+	TracepointSkbCopyDatagramIovec       *ebpf.Program `ebpf:"tracepoint__skb_copy_datagram_iovec"`
 	TracepointSyscallsSysEnterAccept4    *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_accept4"`
 	TracepointSyscallsSysEnterClose      *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_close"`
 	TracepointSyscallsSysEnterConnect    *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_connect"`
@@ -510,6 +512,7 @@ func (p *AgentPrograms) Close() error {
 		p.TracepointNetifReceiveSkb,
 		p.TracepointSchedSchedProcessExec,
 		p.TracepointSchedSchedProcessExit,
+		p.TracepointSkbCopyDatagramIovec,
 		p.TracepointSyscallsSysEnterAccept4,
 		p.TracepointSyscallsSysEnterClose,
 		p.TracepointSyscallsSysEnterConnect,

--- a/bpf/agent_x86_bpfel.go
+++ b/bpf/agent_x86_bpfel.go
@@ -276,6 +276,7 @@ type AgentProgramSpecs struct {
 	TracepointNetifReceiveSkb            *ebpf.ProgramSpec `ebpf:"tracepoint__netif_receive_skb"`
 	TracepointSchedSchedProcessExec      *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit      *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
+	TracepointSkbCopyDatagramIovec       *ebpf.ProgramSpec `ebpf:"tracepoint__skb_copy_datagram_iovec"`
 	TracepointSyscallsSysEnterAccept4    *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_accept4"`
 	TracepointSyscallsSysEnterClose      *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_close"`
 	TracepointSyscallsSysEnterConnect    *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_connect"`
@@ -461,6 +462,7 @@ type AgentPrograms struct {
 	TracepointNetifReceiveSkb            *ebpf.Program `ebpf:"tracepoint__netif_receive_skb"`
 	TracepointSchedSchedProcessExec      *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit      *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
+	TracepointSkbCopyDatagramIovec       *ebpf.Program `ebpf:"tracepoint__skb_copy_datagram_iovec"`
 	TracepointSyscallsSysEnterAccept4    *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_accept4"`
 	TracepointSyscallsSysEnterClose      *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_close"`
 	TracepointSyscallsSysEnterConnect    *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_connect"`
@@ -510,6 +512,7 @@ func (p *AgentPrograms) Close() error {
 		p.TracepointNetifReceiveSkb,
 		p.TracepointSchedSchedProcessExec,
 		p.TracepointSchedSchedProcessExit,
+		p.TracepointSkbCopyDatagramIovec,
 		p.TracepointSyscallsSysEnterAccept4,
 		p.TracepointSyscallsSysEnterClose,
 		p.TracepointSyscallsSysEnterConnect,

--- a/bpf/agentlagacykernel310_arm64_bpfel.go
+++ b/bpf/agentlagacykernel310_arm64_bpfel.go
@@ -73,6 +73,7 @@ type AgentLagacyKernel310ProgramSpecs struct {
 	TracepointNetifReceiveSkb            *ebpf.ProgramSpec `ebpf:"tracepoint__netif_receive_skb"`
 	TracepointSchedSchedProcessExec      *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit      *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
+	TracepointSkbCopyDatagramIovec       *ebpf.ProgramSpec `ebpf:"tracepoint__skb_copy_datagram_iovec"`
 	TracepointSyscallsSysEnterAccept4    *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_accept4"`
 	TracepointSyscallsSysEnterClose      *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_close"`
 	TracepointSyscallsSysEnterConnect    *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_connect"`
@@ -258,6 +259,7 @@ type AgentLagacyKernel310Programs struct {
 	TracepointNetifReceiveSkb            *ebpf.Program `ebpf:"tracepoint__netif_receive_skb"`
 	TracepointSchedSchedProcessExec      *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit      *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
+	TracepointSkbCopyDatagramIovec       *ebpf.Program `ebpf:"tracepoint__skb_copy_datagram_iovec"`
 	TracepointSyscallsSysEnterAccept4    *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_accept4"`
 	TracepointSyscallsSysEnterClose      *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_close"`
 	TracepointSyscallsSysEnterConnect    *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_connect"`
@@ -307,6 +309,7 @@ func (p *AgentLagacyKernel310Programs) Close() error {
 		p.TracepointNetifReceiveSkb,
 		p.TracepointSchedSchedProcessExec,
 		p.TracepointSchedSchedProcessExit,
+		p.TracepointSkbCopyDatagramIovec,
 		p.TracepointSyscallsSysEnterAccept4,
 		p.TracepointSyscallsSysEnterClose,
 		p.TracepointSyscallsSysEnterConnect,

--- a/bpf/agentlagacykernel310_x86_bpfel.go
+++ b/bpf/agentlagacykernel310_x86_bpfel.go
@@ -73,6 +73,7 @@ type AgentLagacyKernel310ProgramSpecs struct {
 	TracepointNetifReceiveSkb            *ebpf.ProgramSpec `ebpf:"tracepoint__netif_receive_skb"`
 	TracepointSchedSchedProcessExec      *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit      *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
+	TracepointSkbCopyDatagramIovec       *ebpf.ProgramSpec `ebpf:"tracepoint__skb_copy_datagram_iovec"`
 	TracepointSyscallsSysEnterAccept4    *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_accept4"`
 	TracepointSyscallsSysEnterClose      *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_close"`
 	TracepointSyscallsSysEnterConnect    *ebpf.ProgramSpec `ebpf:"tracepoint__syscalls__sys_enter_connect"`
@@ -258,6 +259,7 @@ type AgentLagacyKernel310Programs struct {
 	TracepointNetifReceiveSkb            *ebpf.Program `ebpf:"tracepoint__netif_receive_skb"`
 	TracepointSchedSchedProcessExec      *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit      *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
+	TracepointSkbCopyDatagramIovec       *ebpf.Program `ebpf:"tracepoint__skb_copy_datagram_iovec"`
 	TracepointSyscallsSysEnterAccept4    *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_accept4"`
 	TracepointSyscallsSysEnterClose      *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_close"`
 	TracepointSyscallsSysEnterConnect    *ebpf.Program `ebpf:"tracepoint__syscalls__sys_enter_connect"`
@@ -307,6 +309,7 @@ func (p *AgentLagacyKernel310Programs) Close() error {
 		p.TracepointNetifReceiveSkb,
 		p.TracepointSchedSchedProcessExec,
 		p.TracepointSchedSchedProcessExit,
+		p.TracepointSkbCopyDatagramIovec,
 		p.TracepointSyscallsSysEnterAccept4,
 		p.TracepointSyscallsSysEnterClose,
 		p.TracepointSyscallsSysEnterConnect,

--- a/bpf/pktlatency.bpf.c
+++ b/bpf/pktlatency.bpf.c
@@ -583,6 +583,16 @@ int BPF_KPROBE(skb_copy_datagram_iovec, struct sk_buff *skb, int offset, struct 
 	return handle_skb_data_copy(ctx, skb, offset, to, len);
 }
 
+SEC("tracepoint/skb/skb_copy_datagram_iovec")
+int tracepoint__skb_copy_datagram_iovec(struct trace_event_raw_skb_copy_datagram_iovec  *ctx) {
+	void *p = (void*)ctx + sizeof(struct trace_entry);
+	struct sk_buff *skb;
+	bpf_probe_read_kernel(&skb, sizeof(struct sk_buff *), p);
+	p += sizeof(struct sk_buff *);
+	int len = 0;
+	bpf_probe_read_kernel(&len, sizeof(int), p);
+	return handle_skb_data_copy(ctx, skb, 0, NULL, len);
+}
 
 SEC("tracepoint/net/netif_receive_skb")
 int tracepoint__netif_receive_skb(struct trace_event_raw_net_dev_template  *ctx) {


### PR DESCRIPTION
CLOSE #117 
use `tracepoint/skb/skb_copy_datagram_iovec` to replace `kprobe/skb_copy_datagram_iovec` or `kprobe/__skb_datagram_iter`