### PR TITLE
user: add command-line  options to set perf event buffer size

### DIFF
--- a/agent/agent.go
+++ b/agent/agent.go
@@ -112,19 +112,19 @@ func SetupAgent(options ac.AgentOptions) {
 		_bf.Links = bf.Links
 		_bf.Objs = bf.Objs
 
-		err = bpf.PullSyscallDataEvents(ctx, pm.GetSyscallEventsChannels(), options.SyscallMapSize, options.CustomSyscallEventHook)
+		err = bpf.PullSyscallDataEvents(ctx, pm.GetSyscallEventsChannels(), options.SyscallPerfEventMapPageNum, options.CustomSyscallEventHook)
 		if err != nil {
 			return
 		}
-		err = bpf.PullSslDataEvents(ctx, pm.GetSslEventsChannels(), options.SslMapSize, options.CustomSslEventHook)
+		err = bpf.PullSslDataEvents(ctx, pm.GetSslEventsChannels(), options.SslPerfEventMapPageNum, options.CustomSslEventHook)
 		if err != nil {
 			return
 		}
-		err = bpf.PullConnDataEvents(ctx, pm.GetConnEventsChannels(), options.ConnMapSize, options.CustomConnEventHook)
+		err = bpf.PullConnDataEvents(ctx, pm.GetConnEventsChannels(), options.ConnPerfEventMapPageNum, options.CustomConnEventHook)
 		if err != nil {
 			return
 		}
-		err = bpf.PullKernEvents(ctx, pm.GetKernEventsChannels(), options.KernMapSize, options.CustomKernEventHook)
+		err = bpf.PullKernEvents(ctx, pm.GetKernEventsChannels(), options.KernPerfEventMapPageNum, options.CustomKernEventHook)
 		if err != nil {
 			return
 		}

--- a/agent/agent.go
+++ b/agent/agent.go
@@ -112,19 +112,19 @@ func SetupAgent(options ac.AgentOptions) {
 		_bf.Links = bf.Links
 		_bf.Objs = bf.Objs
 
-		err = bpf.PullSyscallDataEvents(ctx, pm.GetSyscallEventsChannels(), 2048, options.CustomSyscallEventHook)
+		err = bpf.PullSyscallDataEvents(ctx, pm.GetSyscallEventsChannels(), options.SyscallMapSize, options.CustomSyscallEventHook)
 		if err != nil {
 			return
 		}
-		err = bpf.PullSslDataEvents(ctx, pm.GetSslEventsChannels(), 512, options.CustomSslEventHook)
+		err = bpf.PullSslDataEvents(ctx, pm.GetSslEventsChannels(), options.SslMapSize, options.CustomSslEventHook)
 		if err != nil {
 			return
 		}
-		err = bpf.PullConnDataEvents(ctx, pm.GetConnEventsChannels(), 4, options.CustomConnEventHook)
+		err = bpf.PullConnDataEvents(ctx, pm.GetConnEventsChannels(), options.ConnMapSize, options.CustomConnEventHook)
 		if err != nil {
 			return
 		}
-		err = bpf.PullKernEvents(ctx, pm.GetKernEventsChannels(), 32, options.CustomKernEventHook)
+		err = bpf.PullKernEvents(ctx, pm.GetKernEventsChannels(), options.KernMapSize, options.CustomKernEventHook)
 		if err != nil {
 			return
 		}

--- a/agent/common/options.go
+++ b/agent/common/options.go
@@ -23,10 +23,6 @@ type ConnManagerInitHook func(*conn.ConnManager)
 
 const perfEventDataBufferSize = 30 * 1024 * 1024
 const perfEventControlBufferSize = 1 * 1024 * 1024
-const defaultSyscallMapSize = 2048
-const defaultSslMapSize = 512
-const defaultConnMapSize = 4
-const defaultKernMapSize = 32
 
 type AgentOptions struct {
 	Stopper                chan os.Signal
@@ -69,10 +65,10 @@ type AgentOptions struct {
 	Kv                  *compatible.KernelVersion
 	LoadPorgressChannel chan string
 
-	SyscallMapSize int
-	SslMapSize     int
-	ConnMapSize    int
-	KernMapSize    int
+	SyscallPerfEventMapPageNum int
+	SslPerfEventMapPageNum     int
+	ConnPerfEventMapPageNum    int
+	KernPerfEventMapPageNum    int
 }
 
 func (o AgentOptions) FilterByContainer() bool {
@@ -126,18 +122,6 @@ func ValidateAndRepairOptions(options AgentOptions) AgentOptions {
 	}
 	if newOptions.CriRuntimeEndpoint != "" {
 		newOptions.CriRuntimeEndpoint = getEndpoint(newOptions.CriRuntimeEndpoint)
-	}
-	if newOptions.SyscallMapSize == 0 {
-		newOptions.SyscallMapSize = defaultSyscallMapSize
-	}
-	if newOptions.SslMapSize == 0 {
-		newOptions.SslMapSize = defaultSslMapSize
-	}
-	if newOptions.ConnMapSize == 0 {
-		newOptions.ConnMapSize = defaultConnMapSize
-	}
-	if newOptions.KernMapSize == 0 {
-		newOptions.KernMapSize = defaultKernMapSize
 	}
 	newOptions.WatchOptions.Init()
 	newOptions.LoadPorgressChannel = make(chan string, 10)

--- a/agent/common/options.go
+++ b/agent/common/options.go
@@ -23,6 +23,10 @@ type ConnManagerInitHook func(*conn.ConnManager)
 
 const perfEventDataBufferSize = 30 * 1024 * 1024
 const perfEventControlBufferSize = 1 * 1024 * 1024
+const defaultSyscallMapSize = 2048
+const defaultSslMapSize = 512
+const defaultConnMapSize = 4
+const defaultKernMapSize = 32
 
 type AgentOptions struct {
 	Stopper                chan os.Signal
@@ -64,6 +68,11 @@ type AgentOptions struct {
 	Ctx                 context.Context
 	Kv                  *compatible.KernelVersion
 	LoadPorgressChannel chan string
+
+	SyscallMapSize int
+	SslMapSize     int
+	ConnMapSize    int
+	KernMapSize    int
 }
 
 func (o AgentOptions) FilterByContainer() bool {
@@ -117,6 +126,18 @@ func ValidateAndRepairOptions(options AgentOptions) AgentOptions {
 	}
 	if newOptions.CriRuntimeEndpoint != "" {
 		newOptions.CriRuntimeEndpoint = getEndpoint(newOptions.CriRuntimeEndpoint)
+	}
+	if newOptions.SyscallMapSize == 0 {
+		newOptions.SyscallMapSize = defaultSyscallMapSize
+	}
+	if newOptions.SslMapSize == 0 {
+		newOptions.SslMapSize = defaultSslMapSize
+	}
+	if newOptions.ConnMapSize == 0 {
+		newOptions.ConnMapSize = defaultConnMapSize
+	}
+	if newOptions.KernMapSize == 0 {
+		newOptions.KernMapSize = defaultKernMapSize
 	}
 	newOptions.WatchOptions.Init()
 	newOptions.LoadPorgressChannel = make(chan string, 10)

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -71,6 +71,11 @@ func startAgent() {
 	options.ContainerName = ContainerName
 	options.PodName = PodName
 
+	options.SyscallMapSize = SyscallMapSize
+	options.SslMapSize = SslMapSize
+	options.ConnMapSize = ConnMapSize
+	options.KernMapSize = KernMapSize
+
 	InitLog()
 	common.AgentLog.Infoln("Kyanos starting...")
 	if viper.GetBool(common.DaemonVarName) {

--- a/cmd/common.go
+++ b/cmd/common.go
@@ -71,11 +71,6 @@ func startAgent() {
 	options.ContainerName = ContainerName
 	options.PodName = PodName
 
-	options.SyscallMapSize = SyscallMapSize
-	options.SslMapSize = SslMapSize
-	options.ConnMapSize = ConnMapSize
-	options.KernMapSize = KernMapSize
-
 	InitLog()
 	common.AgentLog.Infoln("Kyanos starting...")
 	if viper.GetBool(common.DaemonVarName) {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,10 +58,6 @@ var CriRuntimeEndpoint string
 var ContainerId string
 var ContainerName string
 var PodName string
-var SyscallMapSize int
-var SslMapSize int
-var ConnMapSize int
-var KernMapSize int
 
 func init() {
 	rootCmd.PersistentFlags().StringSliceVarP(&FilterPids, "pids", "p", []string{}, "Filter by pids, seperate by ','")
@@ -94,11 +90,11 @@ func init() {
 			fmt.Sprintf("(default: uses in order the first successful one of [%s])",
 				strings.Join(getDefaultCriRuntimeEndpoint(), ", ")))
 
-	// mapsize
-	rootCmd.PersistentFlags().IntVar(&SyscallMapSize, "syscall-mapsize", 2048, "eBPF map size for syscall data events buffer. default:2048 * PAGESIZE.")
-	rootCmd.PersistentFlags().IntVar(&SslMapSize, "ssl-mapsize", 512, "eBPF map size for ssl data events buffer. default:512 * PAGESIZE.")
-	rootCmd.PersistentFlags().IntVar(&ConnMapSize, "conn-mapsize", 4, "eBPF map size for conn data events buffer. default:4 * PAGESIZE.")
-	rootCmd.PersistentFlags().IntVar(&KernMapSize, "kern-mapsize", 32, "eBPF map size for kern events buffer. default:32 * PAGESIZE.")
+	// pageNum of eBPF map
+	rootCmd.PersistentFlags().IntVar(&options.SyscallPerfEventMapPageNum, "syscall-perf-event-map-page-num", 2048, "pageNum of eBPF map size for syscall data events buffer")
+	rootCmd.PersistentFlags().IntVar(&options.SslPerfEventMapPageNum, "ssl-perf-event-map-page-num", 512, "pageNum of eBPF map size for ssl data events buffer")
+	rootCmd.PersistentFlags().IntVar(&options.ConnPerfEventMapPageNum, "conn-perf-event-map-page-num", 4, "pageNum of eBPF map size for conn data events buffer")
+	rootCmd.PersistentFlags().IntVar(&options.KernPerfEventMapPageNum, "kern-perf-event-map-page-num", 32, "pageNum of eBPF map size for kern events buffer")
 
 	// internal
 	rootCmd.PersistentFlags().BoolVar(&options.PerformanceMode, "performance-mode", true, "--performance false")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -58,6 +58,10 @@ var CriRuntimeEndpoint string
 var ContainerId string
 var ContainerName string
 var PodName string
+var SyscallMapSize int
+var SslMapSize int
+var ConnMapSize int
+var KernMapSize int
 
 func init() {
 	rootCmd.PersistentFlags().StringSliceVarP(&FilterPids, "pids", "p", []string{}, "Filter by pids, seperate by ','")
@@ -89,6 +93,12 @@ func init() {
 		"Address of CRI container runtime service "+
 			fmt.Sprintf("(default: uses in order the first successful one of [%s])",
 				strings.Join(getDefaultCriRuntimeEndpoint(), ", ")))
+
+	// mapsize
+	rootCmd.PersistentFlags().IntVar(&SyscallMapSize, "syscall-mapsize", 2048, "eBPF map size for syscall data events buffer. default:2048 * PAGESIZE.")
+	rootCmd.PersistentFlags().IntVar(&SslMapSize, "ssl-mapsize", 512, "eBPF map size for ssl data events buffer. default:512 * PAGESIZE.")
+	rootCmd.PersistentFlags().IntVar(&ConnMapSize, "conn-mapsize", 4, "eBPF map size for conn data events buffer. default:4 * PAGESIZE.")
+	rootCmd.PersistentFlags().IntVar(&KernMapSize, "kern-mapsize", 32, "eBPF map size for kern events buffer. default:32 * PAGESIZE.")
 
 	// internal
 	rootCmd.PersistentFlags().BoolVar(&options.PerformanceMode, "performance-mode", true, "--performance false")

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -112,6 +112,10 @@ func init() {
 	rootCmd.PersistentFlags().MarkHidden("data-perf-event-buffer-size")
 	rootCmd.PersistentFlags().MarkHidden("performance-mode")
 	rootCmd.PersistentFlags().MarkHidden("conntrack-close-wait-time-mills")
+	rootCmd.PersistentFlags().MarkHidden("syscall-perf-event-map-page-num")
+	rootCmd.PersistentFlags().MarkHidden("ssl-perf-event-map-page-num")
+	rootCmd.PersistentFlags().MarkHidden("conn-perf-event-map-page-num")
+	rootCmd.PersistentFlags().MarkHidden("kern-perf-event-map-page-num")
 
 	rootCmd.Flags().SortFlags = false
 	rootCmd.PersistentFlags().SortFlags = false


### PR DESCRIPTION
add `syscall-perf-event-map-page-num`, `ssl-perf-event-map-page-num`, `conn-perf-event-map-page-num`, `kern-perf-event-map-page-num` command-line options to set pageNum of `SyscallDataEvents`, `SslDataEvents`, `ConnDataEvents` and `KernEvents`.

This will fix #245 