### PR TITLE
fix: handle big syscall data (truncated) properly

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -161,6 +161,23 @@ jobs:
             sudo chmod +x /usr/local/bin/docker-compose
             docker-compose --version
 
+      - name: Test Truncated Data parsing
+        uses: cilium/little-vm-helper@97c89f004bd0ab4caeacfe92ebc956e13e362e6b # v0.0.19
+        if: ${{ !contains(fromJSON('["4.19-20240912.022020", "5.4-20240912.022020"]'), matrix.kernel) }}
+        with:
+          provision: 'false'
+          cmd: |
+            set -euxo pipefail
+            uname -a
+            cat /etc/issue
+            pushd /host
+            if [ -f "/var/lib/kyanos/btf/current.btf" ]; then  
+                bash /host/testdata/test_truncated_data.sh 'sudo /host/kyanos/kyanos $kyanos_log_option --btf /var/lib/kyanos/btf/current.btf'
+            else  
+                bash /host/testdata/test_truncated_data.sh 'sudo /host/kyanos/kyanos $kyanos_log_option'
+            fi
+            popd
+
       - name: Test Kafka
         uses: cilium/little-vm-helper@97c89f004bd0ab4caeacfe92ebc956e13e362e6b # v0.0.19
         with:

--- a/agent/conn/processor.go
+++ b/agent/conn/processor.go
@@ -309,10 +309,10 @@ func (p *Processor) run() {
 		case event := <-p.firstPacketsEvents:
 			p.handleFirstPacketEvent(event, recordChannel)
 		case <-ticker.C:
-			p.processTimedKernEvents(recordChannel)
-			p.processTimedSyscallEvents(recordChannel)
 			p.processTimedSslEvents(recordChannel)
+			p.processTimedKernEvents(recordChannel)
 			p.processOldFirstPacketEvents(recordChannel)
+			p.processTimedSyscallEvents(recordChannel)
 		}
 	}
 }

--- a/agent/protocol/fakedata.go
+++ b/agent/protocol/fakedata.go
@@ -1,0 +1,42 @@
+package protocol
+
+import "strings"
+
+const fakeDataMarkPrefix = "__FAKE_DATA__"
+const fakeDataMarkLen = len(fakeDataMarkPrefix) + 4
+
+func MakeNewFakeData(size uint32) ([]byte, bool) {
+	if size < uint32(fakeDataMarkLen) {
+		return nil, false
+	} else {
+		buf := make([]byte, size)
+		copy(buf, fakeDataMarkPrefix)
+		size -= uint32(fakeDataMarkLen)
+		lenByte := []byte{byte(size >> 24), byte(size >> 16), byte(size >> 8), byte(size)}
+		buf[fakeDataMarkLen] = lenByte[0]
+		buf[fakeDataMarkLen+1] = lenByte[1]
+		buf[fakeDataMarkLen+2] = lenByte[2]
+		buf[fakeDataMarkLen+3] = lenByte[3]
+		return buf, true
+	}
+}
+
+func fakeDataMarkIndex(buf []byte) (int, bool) {
+	if len(buf) < fakeDataMarkLen {
+		return -1, false
+	}
+	idx := strings.Index(string(buf), fakeDataMarkPrefix)
+	if idx < 0 {
+		return -1, false
+	}
+	return idx, true
+}
+
+func getFakeDataSize(buf []byte, pos int) uint32 {
+	buf = buf[pos:]
+	if len(buf) < fakeDataMarkLen {
+		return 0
+	} else {
+		return uint32(buf[fakeDataMarkLen])<<24 | uint32(buf[fakeDataMarkLen+1])<<16 | uint32(buf[fakeDataMarkLen+2])<<8 | uint32(buf[fakeDataMarkLen+3])
+	}
+}

--- a/agent/protocol/http_test.go
+++ b/agent/protocol/http_test.go
@@ -153,7 +153,7 @@ func TestParseResponse(t *testing.T) {
 
 	parser := protocol.HTTPStreamParser{}
 
-	parseResult := parser.ParseResponse(httpMessage, protocol.Response, 10, 20)
+	parseResult := parser.ParseResponse(httpMessage, protocol.Response, 10, 20, buffer)
 
 	assert.Equal(t, protocol.Success, parseResult.ParseState)
 	assert.Equal(t, 1, len(parseResult.ParsedMessages))

--- a/testdata/test_truncated_data.sh
+++ b/testdata/test_truncated_data.sh
@@ -1,0 +1,69 @@
+#!/usr/bin/env bash
+. $(dirname "$0")/common.sh
+set -ex
+
+CMD="$1"
+DOCKER_REGISTRY="$2"
+FILE_PREFIX="/tmp/kyanos"
+CLIENT_LNAME="${FILE_PREFIX}_truncated_client.log"
+SERVER_LNAME="${FILE_PREFIX}_truncated_server.log"
+
+
+function test_client() {
+    if [ -z "$DOCKER_REGISTRY" ]; then 
+        IMAGE_NAME="lobehub/lobe-chat:v1.46.7"
+    else
+        IMAGE_NAME=$DOCKER_REGISTRY"/lobehub/lobe-chat:v1.46.7"
+    fi
+    docker pull "$IMAGE_NAME"
+
+    cname='lobe'
+    port=3210
+    docker rm -f $cname
+    cid1=$(docker run --name $cname  -p $port:$port -d "$IMAGE_NAME")
+    export cid1
+    echo $cid1
+
+    timeout 30 ${CMD} watch --debug-output http --remote-ports $port 2>&1 | tee "${CLIENT_LNAME}" &
+    sleep 15
+    curl http://localhost:3210
+    wait
+
+    cat "${CLIENT_LNAME}"
+    docker rm -f $cid1 || true
+    check_patterns_in_file "${CLIENT_LNAME}" "localhost:3210"
+}
+
+
+function test_server() {
+    if [ -z "$DOCKER_REGISTRY" ]; then 
+        IMAGE_NAME="lobehub/lobe-chat:v1.46.7"
+    else
+        IMAGE_NAME=$DOCKER_REGISTRY"/lobehub/lobe-chat:v1.46.7"
+    fi
+    docker pull "$IMAGE_NAME"
+
+    cname='lobe'
+    port=3210
+    docker rm -f $cname
+    cid1=$(docker run --name $cname  -p $port:$port -d "$IMAGE_NAME")
+    export cid1
+    echo $cid1
+
+    timeout 30 ${CMD} watch --debug-output http --local-ports $port 2>&1 | tee "${SERVER_LNAME}" &
+    sleep 15
+    curl http://localhost:3210
+    wait
+
+    cat "${SERVER_LNAME}"
+    docker rm -f $cid1 || true
+    check_patterns_in_file "${SERVER_LNAME}" "localhost:3210"
+}
+
+
+function main() {
+    test_client
+    test_server
+}
+
+main


### PR DESCRIPTION
When we fail to read the http body, it might be due to the response being too large, causing syscall data to be missing when transferred to user space. 

Here, we attempt to find a boundary. If found, that's ideal and we return immediately. Otherwise, we try to locate a Fake Data Mark (FDM). When user space detects missing data from the kernel (possibly due to exceeding MAX_MSG_SIZE or situations like readv/writev where a buffer array is read/written at once), it supplements with fake data in user space.

At the beginning of this fake data, an FDM is set, which is a special string. Following the FDM, the length of the supplemental fake data (minus the length of the FDM) is written.