### PR TITLE
feat: support trace socket event for ipv6

### DIFF
--- a/bpf/agent_arm64_bpfel.go
+++ b/bpf/agent_arm64_bpfel.go
@@ -298,6 +298,7 @@ type AgentProgramSpecs struct {
 	TcpRcvEstablished                    *ebpf.ProgramSpec `ebpf:"tcp_rcv_established"`
 	TcpV4DoRcv                           *ebpf.ProgramSpec `ebpf:"tcp_v4_do_rcv"`
 	TcpV4Rcv                             *ebpf.ProgramSpec `ebpf:"tcp_v4_rcv"`
+	TcpV6DoRcv                           *ebpf.ProgramSpec `ebpf:"tcp_v6_do_rcv"`
 	TracepointNetifReceiveSkb            *ebpf.ProgramSpec `ebpf:"tracepoint__netif_receive_skb"`
 	TracepointSchedSchedProcessExec      *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit      *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
@@ -493,6 +494,7 @@ type AgentPrograms struct {
 	TcpRcvEstablished                    *ebpf.Program `ebpf:"tcp_rcv_established"`
 	TcpV4DoRcv                           *ebpf.Program `ebpf:"tcp_v4_do_rcv"`
 	TcpV4Rcv                             *ebpf.Program `ebpf:"tcp_v4_rcv"`
+	TcpV6DoRcv                           *ebpf.Program `ebpf:"tcp_v6_do_rcv"`
 	TracepointNetifReceiveSkb            *ebpf.Program `ebpf:"tracepoint__netif_receive_skb"`
 	TracepointSchedSchedProcessExec      *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit      *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
@@ -543,6 +545,7 @@ func (p *AgentPrograms) Close() error {
 		p.TcpRcvEstablished,
 		p.TcpV4DoRcv,
 		p.TcpV4Rcv,
+		p.TcpV6DoRcv,
 		p.TracepointNetifReceiveSkb,
 		p.TracepointSchedSchedProcessExec,
 		p.TracepointSchedSchedProcessExit,

--- a/bpf/agent_x86_bpfel.go
+++ b/bpf/agent_x86_bpfel.go
@@ -298,6 +298,7 @@ type AgentProgramSpecs struct {
 	TcpRcvEstablished                    *ebpf.ProgramSpec `ebpf:"tcp_rcv_established"`
 	TcpV4DoRcv                           *ebpf.ProgramSpec `ebpf:"tcp_v4_do_rcv"`
 	TcpV4Rcv                             *ebpf.ProgramSpec `ebpf:"tcp_v4_rcv"`
+	TcpV6DoRcv                           *ebpf.ProgramSpec `ebpf:"tcp_v6_do_rcv"`
 	TracepointNetifReceiveSkb            *ebpf.ProgramSpec `ebpf:"tracepoint__netif_receive_skb"`
 	TracepointSchedSchedProcessExec      *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit      *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
@@ -493,6 +494,7 @@ type AgentPrograms struct {
 	TcpRcvEstablished                    *ebpf.Program `ebpf:"tcp_rcv_established"`
 	TcpV4DoRcv                           *ebpf.Program `ebpf:"tcp_v4_do_rcv"`
 	TcpV4Rcv                             *ebpf.Program `ebpf:"tcp_v4_rcv"`
+	TcpV6DoRcv                           *ebpf.Program `ebpf:"tcp_v6_do_rcv"`
 	TracepointNetifReceiveSkb            *ebpf.Program `ebpf:"tracepoint__netif_receive_skb"`
 	TracepointSchedSchedProcessExec      *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit      *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
@@ -543,6 +545,7 @@ func (p *AgentPrograms) Close() error {
 		p.TcpRcvEstablished,
 		p.TcpV4DoRcv,
 		p.TcpV4Rcv,
+		p.TcpV6DoRcv,
 		p.TracepointNetifReceiveSkb,
 		p.TracepointSchedSchedProcessExec,
 		p.TracepointSchedSchedProcessExit,

--- a/bpf/agentlagacykernel310_arm64_bpfel.go
+++ b/bpf/agentlagacykernel310_arm64_bpfel.go
@@ -70,6 +70,7 @@ type AgentLagacyKernel310ProgramSpecs struct {
 	TcpRcvEstablished                    *ebpf.ProgramSpec `ebpf:"tcp_rcv_established"`
 	TcpV4DoRcv                           *ebpf.ProgramSpec `ebpf:"tcp_v4_do_rcv"`
 	TcpV4Rcv                             *ebpf.ProgramSpec `ebpf:"tcp_v4_rcv"`
+	TcpV6DoRcv                           *ebpf.ProgramSpec `ebpf:"tcp_v6_do_rcv"`
 	TracepointNetifReceiveSkb            *ebpf.ProgramSpec `ebpf:"tracepoint__netif_receive_skb"`
 	TracepointSchedSchedProcessExec      *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit      *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
@@ -265,6 +266,7 @@ type AgentLagacyKernel310Programs struct {
 	TcpRcvEstablished                    *ebpf.Program `ebpf:"tcp_rcv_established"`
 	TcpV4DoRcv                           *ebpf.Program `ebpf:"tcp_v4_do_rcv"`
 	TcpV4Rcv                             *ebpf.Program `ebpf:"tcp_v4_rcv"`
+	TcpV6DoRcv                           *ebpf.Program `ebpf:"tcp_v6_do_rcv"`
 	TracepointNetifReceiveSkb            *ebpf.Program `ebpf:"tracepoint__netif_receive_skb"`
 	TracepointSchedSchedProcessExec      *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit      *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
@@ -315,6 +317,7 @@ func (p *AgentLagacyKernel310Programs) Close() error {
 		p.TcpRcvEstablished,
 		p.TcpV4DoRcv,
 		p.TcpV4Rcv,
+		p.TcpV6DoRcv,
 		p.TracepointNetifReceiveSkb,
 		p.TracepointSchedSchedProcessExec,
 		p.TracepointSchedSchedProcessExit,

--- a/bpf/agentlagacykernel310_x86_bpfel.go
+++ b/bpf/agentlagacykernel310_x86_bpfel.go
@@ -70,6 +70,7 @@ type AgentLagacyKernel310ProgramSpecs struct {
 	TcpRcvEstablished                    *ebpf.ProgramSpec `ebpf:"tcp_rcv_established"`
 	TcpV4DoRcv                           *ebpf.ProgramSpec `ebpf:"tcp_v4_do_rcv"`
 	TcpV4Rcv                             *ebpf.ProgramSpec `ebpf:"tcp_v4_rcv"`
+	TcpV6DoRcv                           *ebpf.ProgramSpec `ebpf:"tcp_v6_do_rcv"`
 	TracepointNetifReceiveSkb            *ebpf.ProgramSpec `ebpf:"tracepoint__netif_receive_skb"`
 	TracepointSchedSchedProcessExec      *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit      *ebpf.ProgramSpec `ebpf:"tracepoint__sched__sched_process_exit"`
@@ -265,6 +266,7 @@ type AgentLagacyKernel310Programs struct {
 	TcpRcvEstablished                    *ebpf.Program `ebpf:"tcp_rcv_established"`
 	TcpV4DoRcv                           *ebpf.Program `ebpf:"tcp_v4_do_rcv"`
 	TcpV4Rcv                             *ebpf.Program `ebpf:"tcp_v4_rcv"`
+	TcpV6DoRcv                           *ebpf.Program `ebpf:"tcp_v6_do_rcv"`
 	TracepointNetifReceiveSkb            *ebpf.Program `ebpf:"tracepoint__netif_receive_skb"`
 	TracepointSchedSchedProcessExec      *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exec"`
 	TracepointSchedSchedProcessExit      *ebpf.Program `ebpf:"tracepoint__sched__sched_process_exit"`
@@ -315,6 +317,7 @@ func (p *AgentLagacyKernel310Programs) Close() error {
 		p.TcpRcvEstablished,
 		p.TcpV4DoRcv,
 		p.TcpV4Rcv,
+		p.TcpV6DoRcv,
 		p.TracepointNetifReceiveSkb,
 		p.TracepointSchedSchedProcessExec,
 		p.TracepointSchedSchedProcessExit,

--- a/bpf/loader/loader.go
+++ b/bpf/loader/loader.go
@@ -509,14 +509,18 @@ func attachBpfProgs(ifName string, kernelVersion *compatible.KernelVersion, opti
 					if isNonCriticalStep {
 						common.AgentLog.Debugf("Attach failed: %v, functions: %v skip it because it's a non-criticalstep", err, functions)
 					} else {
-						return nil, fmt.Errorf("Attach failed: %v, functions: %v", err, functions)
+						return nil, fmt.Errorf("attach failed: %v, functions: %v", err, functions)
 					}
 				} else {
 					common.AgentLog.Debugf("Attach failed but has fallback: %v, functions: %v", err, functions)
 				}
 			} else {
 				linkList.PushBack(l)
-				break
+				if idx < len(functions)-1 && !functions[idx+1].IsBackup() {
+					continue
+				} else {
+					break
+				}
 			}
 		}
 	}

--- a/bpf/pktlatency.bpf.c
+++ b/bpf/pktlatency.bpf.c
@@ -297,21 +297,16 @@ static bool __always_inline use_ipv6(struct sock_common * skc) {
 static bool __always_inline parse_sock_key_sk(struct sock* sk, struct sock_key* key) {
 	struct sock_common *skc = {0};
 	skc = (struct sock_common *)sk;
-	bool supportIpv6 = use_ipv6(skc);
 	switch (_C(skc, skc_family)) {
 		case AF_INET: 
 			key->dip[0] = _C(skc, skc_daddr);
 			key->sip[0] = _C(skc, skc_rcv_saddr);
 			break;
 		case AF_INET6:
-			if (supportIpv6) {
-				bpf_probe_read_kernel((void *)(key->dip), sizeof(struct in6_addr), (const void *)__builtin_preserve_access_index(&((typeof((skc)))((skc)))->skc_v6_daddr)); 
-				bpf_probe_read_kernel((void *)(key->sip), sizeof(struct in6_addr), (const void *)__builtin_preserve_access_index(&((typeof((skc)))((skc)))->skc_v6_rcv_saddr));
-			} else {
-				key->dip[0] = _C(skc, skc_daddr);
-				key->sip[0] = _C(skc, skc_rcv_saddr);
-			}
-		break;
+			bpf_probe_read_kernel((void *)(key->dip), sizeof(struct in6_addr), (const void *)__builtin_preserve_access_index(&((typeof((skc)))((skc)))->skc_v6_daddr.in6_u.u6_addr32)); 
+			bpf_probe_read_kernel((void *)(key->sip), sizeof(struct in6_addr), (const void *)__builtin_preserve_access_index(&((typeof((skc)))((skc)))->skc_v6_rcv_saddr.in6_u.u6_addr32));
+			// bpf_printk("ipv6!, sport: %d, dport: %d", _C(skc, skc_num), _C(skc, skc_dport));
+			break;
 		default:
 			return false;
 	}
@@ -472,7 +467,7 @@ static __always_inline int parse_skb(void* ctx, struct sk_buff *skb, bool sk_not
 		l3 = (void *)eth + ETH_HLEN;
 		BPF_CORE_READ_INTO(&l3_proto, eth, h_proto);
 		l3_proto = bpf_ntohs(l3_proto);
-		// bpf_printk("%s, l3_proto: %x",func_name, l3_proto);
+		// bpf_printk("test l3_proto: %x", l3_proto);
 		if (l3_proto == ETH_P_IP || l3_proto == ETH_P_IPV6) {
 	__l3:	
 			if (!skb_l4_check(trans_header, network_header)) {
@@ -506,7 +501,8 @@ static __always_inline int parse_skb(void* ctx, struct sk_buff *skb, bool sk_not
 				}
 			} else if (l3_proto == ETH_P_IPV6) {
 				proto_l4 = _(ipv6->nexthdr);
-				tcp_len = _C(ipv6, payload_len);
+				tcp_len = bpf_ntohs(_C(ipv6, payload_len));
+				// bpf_printk("testipv6, tcp_len: %d", tcp_len);
 				l4 = l4 ? l4 : ip + sizeof(*ipv6);
 			}else{
 				goto err;
@@ -661,6 +657,13 @@ int BPF_KPROBE(tcp_rcv_established, struct sock *sk, struct sk_buff *skb) {
   
 SEC("kprobe/tcp_v4_do_rcv")
 int BPF_KPROBE(tcp_v4_do_rcv, struct sock *sk, struct sk_buff *skb) { 
+	parse_skb(ctx, skb, 1, TCP_IN);
+	return BPF_OK;
+}
+
+  
+SEC("kprobe/tcp_v6_do_rcv")
+int BPF_KPROBE(tcp_v6_do_rcv, struct sock *sk, struct sk_buff *skb) { 
 	parse_skb(ctx, skb, 1, TCP_IN);
 	return BPF_OK;
 }
@@ -890,14 +893,14 @@ static __inline void read_sockaddr_kernel(struct conn_info_t* conn_info,
 
 	conn_info->laddr.in6.sin6_port = lport;
 	conn_info->raddr.in6.sin6_port = rport;
-  if (family == AF_INET || !use_ipv6(sk_common)) {
+  if (family == AF_INET) {
 	conn_info->laddr.in6.sin6_addr.in6_u.u6_addr32[0] = _C(sk_common, skc_rcv_saddr);
 	conn_info->raddr.in6.sin6_addr.in6_u.u6_addr32[0] = _C(sk_common, skc_daddr);
 	// BPF_CORE_READ_INTO(&conn_info->laddr.in4.sin_addr.s_addr, sk_common, skc_rcv_saddr);
 	// BPF_CORE_READ_INTO(&conn_info->raddr.in4.sin_addr.s_addr, sk_common, skc_daddr);
   } else if (family == AF_INET6) {
-	BPF_CORE_READ_INTO(&conn_info->laddr.in6.sin6_addr, sk_common, skc_v6_rcv_saddr);
-	BPF_CORE_READ_INTO(&conn_info->raddr.in6.sin6_addr, sk_common, skc_v6_daddr);
+	BPF_CORE_READ_INTO(&conn_info->laddr.in6.sin6_addr, sk_common, skc_v6_rcv_saddr.in6_u.u6_addr32);
+	BPF_CORE_READ_INTO(&conn_info->raddr.in6.sin6_addr, sk_common, skc_v6_daddr.in6_u.u6_addr32);
   } 
 }
 
@@ -1041,7 +1044,6 @@ enum endpoint_role_t role, uint64_t start_ts) {
 	
 	// print_sock_key(&key);
 	struct sock_common *sk_common = (struct sock_common *) tcp_sk; 
-	bool is_ipv6 = use_ipv6(sk_common);
 	if (socket == NULL) {
 		// conn_info.laddr.in4.sin_addr.s_addr = role == kRoleClient ? key.sip : key.dip;
 		// conn_info.laddr.in4.sin_port = role == kRoleClient ? key.sport : key.dport;
@@ -1054,7 +1056,7 @@ enum endpoint_role_t role, uint64_t start_ts) {
 		uint16_t family = -1;
 		BPF_CORE_READ_INTO(&family, sk_common, skc_family);
 	// bpf_printk("AF: %d", family);
-		if (family == AF_INET || !is_ipv6) {
+		if (family == AF_INET ) {
 			// conn_info.laddr.in4.sin_addr.s_addr = (u32)key.sip[0] ;
 			// conn_info.raddr.in4.sin_addr.s_addr = (u32)key.dip[0];
 			conn_info.laddr.in6.sin6_addr.in6_u.u6_addr32[0] = (u32)key.sip[0];
@@ -1065,10 +1067,6 @@ enum endpoint_role_t role, uint64_t start_ts) {
 		}
 		conn_info.laddr.sa.sa_family = family;
 		conn_info.raddr.sa.sa_family = family;
-	}
-	if (!use_ipv6(sk_common)) {
-		conn_info.laddr.sa.sa_family = AF_INET;
-		conn_info.raddr.sa.sa_family = AF_INET;
 	}
 
 	// bpf_printk("submit_new_conn laddr: port:%u", conn_info.laddr.in4.sin_port);

--- a/testdata/test_ipv6.sh
+++ b/testdata/test_ipv6.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+. $(dirname "$0")/common.sh
+set -ex
+
+CMD="$1"
+FILE_PREFIX="/tmp/kyanos"
+CLIENT_LNAME="${FILE_PREFIX}_ipv6_client.log"
+
+
+function test_client() {
+    # client start after kyanos
+    timeout 30 ${CMD} watch --debug-output http --comm curl --trace-ssl-event=false 2>&1 | tee "${CLIENT_LNAME}" &
+    sleep 15
+    curl -6 'http://ipv6.baidu.com'  &>/dev/null || true
+    wait
+
+    cat "${CLIENT_LNAME}"
+    cat "${CLIENT_LNAME}" | grep "Host: ipv6.baidu.com"
+}
+
+function main() {
+    test_client
+}
+
+main


### PR DESCRIPTION
Currently github action runner doesn't support ipv6, so only write an e2e test script but not added to test.yml workflow.