### PR TITLE
Update COMPILATION.md

### DIFF
--- a/COMPILATION.md
+++ b/COMPILATION.md
@@ -78,7 +78,7 @@ project.
 > Check if BTF is enabled:
 >
 > ```
-> zgrep CONFIG_DEBUG_INFO_BTF /proc/config.gz
+> ( zgrep CONFIG_DEBUG_INFO_BTF /proc/config.gz ; grep CONFIG_DEBUG_INFO_BTF "/boot/config-$(uname -r)" ) | uniq
 > ```
 >
 > If the result is `CONFIG_DEBUG_INFO_BTF=y`, it means BTF is enabled. If not,

--- a/COMPILATION.md
+++ b/COMPILATION.md
@@ -78,7 +78,7 @@ project.
 > Check if BTF is enabled:
 >
 > ```
-> grep CONFIG_DEBUG_INFO_BTF "/boot/config-$(uname -r)"
+> zgrep CONFIG_DEBUG_INFO_BTF /proc/config.gz
 > ```
 >
 > If the result is `CONFIG_DEBUG_INFO_BTF=y`, it means BTF is enabled. If not,


### PR DESCRIPTION
update instruction for retrieving CONFIG from kernel - as /boot doesn't always contain this information but `/proc/config.gz` does (since Linux 2.6)