### PR TITLE
feat(http): add body regex filtering

### DIFF
--- a/agent/protocol/http.go
+++ b/agent/protocol/http.go
@@ -2,6 +2,7 @@ package protocol
 
 import (
 	"bufio"
+	"bytes"
 	"fmt"
 	"io"
 	"kyanos/agent/buffer"
@@ -289,6 +290,7 @@ type HttpFilter struct {
 	TargetPathPrefix string
 	TargetHostName   string
 	TargetMethods    []string
+	TargetBodyReg    *regexp.Regexp
 	needFilter       *bool
 }
 
@@ -304,24 +306,41 @@ func (filter HttpFilter) FilterByRequest() bool {
 		filter.TargetPathReg != nil ||
 		len(filter.TargetPathPrefix) > 0 ||
 		len(filter.TargetMethods) > 0 ||
-		len(filter.TargetHostName) > 0)
+		len(filter.TargetHostName) > 0 ||
+		filter.TargetBodyReg != nil)
 	return *filter.needFilter
 }
 
 func (filter HttpFilter) FilterByResponse() bool {
-	return false
+	return filter.TargetBodyReg != nil
 }
 
-// Filter filters HTTP requests based on various criteria such as path, path prefix, path regex, method, and host name.
-// It returns true if the request matches all the specified criteria, otherwise it returns false.
-//
-// The filtering logic is as follows:
-// - If TargetPath is specified, the request path must exactly match TargetPath.
-// - If TargetPathPrefix is specified, the request path must start with TargetPathPrefix.
-// - If TargetPathReg is specified, the request path must match the regular expression TargetPathReg.
-// - If TargetMethods is specified, the request method must be one of the methods in TargetMethods.
-// - If TargetHostName is specified, the request host must exactly match TargetHostName.
-func (filter HttpFilter) Filter(parsedReq ParsedMessage, _ ParsedMessage) bool {
+func extractHTTPBody(buf []byte) []byte {
+	bodyStart := bytes.Index(buf, []byte(HTTP_BOUNDARY_MARKER))
+	if bodyStart == -1 {
+		return nil
+	}
+	return buf[bodyStart+len(HTTP_BOUNDARY_MARKER):]
+}
+
+func bodyMatches(msg ParsedMessage, bodyReg *regexp.Regexp) bool {
+	if msg == nil || bodyReg == nil {
+		return false
+	}
+
+	switch typed := msg.(type) {
+	case *ParsedHttpRequest:
+		return bodyReg.Match(extractHTTPBody(typed.buf))
+	case *ParsedHttpResponse:
+		return bodyReg.Match(extractHTTPBody(typed.buf))
+	default:
+		return false
+	}
+}
+
+// Filter filters HTTP requests based on path, path prefix, path regex, method, host name,
+// and optionally request/response body regex content.
+func (filter HttpFilter) Filter(parsedReq ParsedMessage, parsedResp ParsedMessage) bool {
 	req, ok := parsedReq.(*ParsedHttpRequest)
 	if !ok {
 		common.ProtocolParserLog.Warnf("[HttpFilter] cast to http.Request failed: %v\n", req)
@@ -346,6 +365,12 @@ func (filter HttpFilter) Filter(parsedReq ParsedMessage, _ ParsedMessage) bool {
 	}
 
 	if filter.TargetHostName != "" && filter.TargetHostName != req.Host {
+		return false
+	}
+
+	if filter.TargetBodyReg != nil &&
+		!bodyMatches(parsedReq, filter.TargetBodyReg) &&
+		!bodyMatches(parsedResp, filter.TargetBodyReg) {
 		return false
 	}
 

--- a/agent/protocol/http_test.go
+++ b/agent/protocol/http_test.go
@@ -164,6 +164,31 @@ func TestParseResponse(t *testing.T) {
 	assert.Equal(t, uint64(20), message.Seq())
 }
 
+func parseHTTPReqMessage(t *testing.T, raw string) protocol.ParsedMessage {
+	t.Helper()
+
+	parser := protocol.HTTPStreamParser{}
+	result := parser.ParseRequest(raw, protocol.Request, 10, 20)
+	assert.Equal(t, protocol.Success, result.ParseState)
+	assert.Len(t, result.ParsedMessages, 1)
+
+	return result.ParsedMessages[0]
+}
+
+func parseHTTPRespMessage(t *testing.T, raw string) protocol.ParsedMessage {
+	t.Helper()
+
+	streamBuffer := buffer.New(1000)
+	streamBuffer.Add(10, []byte(raw), 10000)
+
+	parser := protocol.HTTPStreamParser{}
+	result := parser.ParseResponse(raw, protocol.Response, 10, 20, streamBuffer)
+	assert.Equal(t, protocol.Success, result.ParseState)
+	assert.Len(t, result.ParsedMessages, 1)
+
+	return result.ParsedMessages[0]
+}
+
 func TestHttpFilter_Filter(t *testing.T) {
 	type fields struct {
 		TargetPath       string
@@ -171,9 +196,11 @@ func TestHttpFilter_Filter(t *testing.T) {
 		TargetPathPrefix string
 		TargetHostName   string
 		TargetMethods    []string
+		TargetBodyReg    *regexp.Regexp
 	}
 	type args struct {
-		parsedReq protocol.ParsedMessage
+		parsedReq  protocol.ParsedMessage
+		parsedResp protocol.ParsedMessage
 	}
 	tests := []struct {
 		name   string
@@ -197,6 +224,7 @@ func TestHttpFilter_Filter(t *testing.T) {
 				parsedReq: &protocol.ParsedHttpRequest{
 					Path: "/foo/bar",
 				},
+				parsedResp: nil,
 			},
 			want: true,
 		},
@@ -209,6 +237,7 @@ func TestHttpFilter_Filter(t *testing.T) {
 				parsedReq: &protocol.ParsedHttpRequest{
 					Path: "/foo/bar/baz",
 				},
+				parsedResp: nil,
 			},
 			want: false,
 		},
@@ -221,6 +250,7 @@ func TestHttpFilter_Filter(t *testing.T) {
 				parsedReq: &protocol.ParsedHttpRequest{
 					Path: "/foo/bar/baz",
 				},
+				parsedResp: nil,
 			},
 			want: true,
 		},
@@ -233,6 +263,7 @@ func TestHttpFilter_Filter(t *testing.T) {
 				parsedReq: &protocol.ParsedHttpRequest{
 					Path: "/test",
 				},
+				parsedResp: nil,
 			},
 			want: false,
 		},
@@ -245,6 +276,7 @@ func TestHttpFilter_Filter(t *testing.T) {
 				parsedReq: &protocol.ParsedHttpRequest{
 					Path: "/foo/bar/100/baz",
 				},
+				parsedResp: nil,
 			},
 			want: true,
 		},
@@ -257,6 +289,7 @@ func TestHttpFilter_Filter(t *testing.T) {
 				parsedReq: &protocol.ParsedHttpRequest{
 					Path: "/test",
 				},
+				parsedResp: nil,
 			},
 			want: false,
 		},
@@ -269,6 +302,7 @@ func TestHttpFilter_Filter(t *testing.T) {
 					Host:   "test.com",
 					Method: "POST",
 				},
+				parsedResp: nil,
 			},
 			want: true,
 		},
@@ -281,6 +315,7 @@ func TestHttpFilter_Filter(t *testing.T) {
 				parsedReq: &protocol.ParsedHttpRequest{
 					Method: "GET",
 				},
+				parsedResp: nil,
 			},
 			want: true,
 		},
@@ -293,6 +328,7 @@ func TestHttpFilter_Filter(t *testing.T) {
 				parsedReq: &protocol.ParsedHttpRequest{
 					Method: "POST",
 				},
+				parsedResp: nil,
 			},
 			want: false,
 		},
@@ -305,6 +341,7 @@ func TestHttpFilter_Filter(t *testing.T) {
 				parsedReq: &protocol.ParsedHttpRequest{
 					Host: "foo.bar",
 				},
+				parsedResp: nil,
 			},
 			want: true,
 		},
@@ -317,6 +354,52 @@ func TestHttpFilter_Filter(t *testing.T) {
 				parsedReq: &protocol.ParsedHttpRequest{
 					Host: "foo.baz",
 				},
+				parsedResp: nil,
+			},
+			want: false,
+		},
+		{
+			name: "filter_by_request_body_regex",
+			fields: fields{
+				TargetBodyReg: regexp.MustCompile(`reqId=123`),
+			},
+			args: args{
+				parsedReq: parseHTTPReqMessage(t,
+					"POST /foo HTTP/1.1\r\nHost: foo.bar\r\nContent-Length: 21\r\n\r\npayload=reqId=123&x=1",
+				),
+				parsedResp: parseHTTPRespMessage(t,
+					"HTTP/1.1 200 OK\r\nContent-Length: 2\r\n\r\nok",
+				),
+			},
+			want: true,
+		},
+		{
+			name: "filter_by_response_body_regex",
+			fields: fields{
+				TargetBodyReg: regexp.MustCompile(`status=ok`),
+			},
+			args: args{
+				parsedReq: parseHTTPReqMessage(t,
+					"POST /foo HTTP/1.1\r\nHost: foo.bar\r\nContent-Length: 6\r\n\r\nhello!",
+				),
+				parsedResp: parseHTTPRespMessage(t,
+					"HTTP/1.1 200 OK\r\nContent-Length: 17\r\n\r\nresult=status=ok!",
+				),
+			},
+			want: true,
+		},
+		{
+			name: "not_filter_by_body_regex",
+			fields: fields{
+				TargetBodyReg: regexp.MustCompile(`reqId=123`),
+			},
+			args: args{
+				parsedReq: parseHTTPReqMessage(t,
+					"POST /foo HTTP/1.1\r\nHost: foo.bar\r\nContent-Length: 7\r\n\r\nnope123",
+				),
+				parsedResp: parseHTTPRespMessage(t,
+					"HTTP/1.1 200 OK\r\nContent-Length: 7\r\n\r\nstillno",
+				),
 			},
 			want: false,
 		},
@@ -329,8 +412,18 @@ func TestHttpFilter_Filter(t *testing.T) {
 				TargetPathPrefix: tt.fields.TargetPathPrefix,
 				TargetHostName:   tt.fields.TargetHostName,
 				TargetMethods:    tt.fields.TargetMethods,
+				TargetBodyReg:    tt.fields.TargetBodyReg,
 			}
-			assert.Equalf(t, tt.want, filter.Filter(tt.args.parsedReq, nil), "Filter(%v, %v)", tt.args.parsedReq, nil)
+			assert.Equalf(t, tt.want, filter.Filter(tt.args.parsedReq, tt.args.parsedResp), "Filter(%v, %v)", tt.args.parsedReq, tt.args.parsedResp)
 		})
 	}
+}
+
+func TestHttpFilter_BodyRegexRequiresResponseFiltering(t *testing.T) {
+	filter := protocol.HttpFilter{
+		TargetBodyReg: regexp.MustCompile(`reqId=123`),
+	}
+
+	assert.True(t, filter.FilterByRequest())
+	assert.True(t, filter.FilterByResponse())
 }

--- a/cmd/http.go
+++ b/cmd/http.go
@@ -8,9 +8,9 @@ import (
 )
 
 var httpCmd = &cobra.Command{
-	Use:   "http [--method METHODS|--path PATH|--path-regex REGEX|--path-prefix PREFIX|--host HOSTNAME]",
+	Use:   "http [--method METHODS|--path PATH|--path-regex REGEX|--path-prefix PREFIX|--host HOSTNAME|--body REGEX]",
 	Short: "watch HTTP message",
-	Long:  `Filter HTTP messages based on method, path (strict, regex, prefix), or host. Filter flags are combined with AND(&&).`,
+	Long:  `Filter HTTP messages based on method, path (strict, regex, prefix), host, or request/response body content. Filter flags are combined with AND(&&).`,
 	Run: func(cmd *cobra.Command, args []string) {
 		methods, err := cmd.Flags().GetStringSlice("method")
 		if err != nil {
@@ -26,6 +26,7 @@ var httpCmd = &cobra.Command{
 		}
 		var (
 			pathReg *regexp.Regexp
+			bodyReg *regexp.Regexp
 		)
 		if pathRegStr, err := cmd.Flags().GetString("path-regex"); err != nil {
 			logger.Fatalf("invalid path-regex: %v\n", err)
@@ -38,6 +39,13 @@ var httpCmd = &cobra.Command{
 		if err != nil {
 			logger.Fatalf("invalid path-prefix: %v\n", err)
 		}
+		if bodyRegStr, err := cmd.Flags().GetString("body"); err != nil {
+			logger.Fatalf("invalid body: %v\n", err)
+		} else if len(bodyRegStr) > 0 {
+			if bodyReg, err = regexp.Compile(bodyRegStr); err != nil {
+				logger.Fatalf("invalid body: %v\n", err)
+			}
+		}
 
 		options.MessageFilter = protocol.HttpFilter{
 			TargetPath:       path,
@@ -45,6 +53,7 @@ var httpCmd = &cobra.Command{
 			TargetPathPrefix: pathPrefix,
 			TargetHostName:   host,
 			TargetMethods:    methods,
+			TargetBodyReg:    bodyReg,
 		}
 		options.LatencyFilter = initLatencyFilter(cmd)
 		options.SizeFilter = initSizeFilter(cmd)
@@ -58,6 +67,7 @@ func init() {
 	httpCmd.Flags().String("path", "", "Specify the HTTP path to monitor, like: '/foo/bar'")
 	httpCmd.Flags().String("path-regex", "", "Specify the regex for HTTP path to monitor, like: '\\/foo\\/bar\\/\\d+'")
 	httpCmd.Flags().String("path-prefix", "", "Specify the prefix of HTTP path to monitor, like: '/foo'")
+	httpCmd.Flags().String("body", "", "Specify a regex to match against HTTP request or response bodies, like: 'reqId=123'")
 
 	httpCmd.Flags().SortFlags = false
 	httpCmd.PersistentFlags().SortFlags = false


### PR DESCRIPTION
## Problem
HTTP filtering currently supports method, path, prefix, regex, and host matching, but there is no way to filter on request or response body content.

## What changed
- added a `--body` regex flag to the `http` command
- extended `protocol.HttpFilter` with body regex support
- matched the regex against the HTTP payload section after `

`
- enabled response-side filtering when a body regex is configured
- added HTTP filter tests for request-body matches, response-body matches, and non-matches

## Why this fixes it
This keeps the new behavior inside the existing HTTP filter path, so body matching works alongside the current path/method/host filters instead of introducing a separate filtering stage.

## Verification
- `GOOS=linux GOARCH=arm64 go test -c ./agent/protocol`
- parser sanity check for the new request/response body fixtures using Go's stdlib `net/http`

I could not run the full Go test suite on this macOS machine because the repo's Linux-only code and BPF toolchain are required for end-to-end test execution.

Fixes #263