### PR TITLE
feat(redis): support excluded commands

### DIFF
--- a/agent/protocol/redis..go
+++ b/agent/protocol/redis..go
@@ -606,9 +606,19 @@ func init() {
 }
 
 type RedisFilter struct {
-	TargetCommands []string
-	TargetKeys     []string
-	KeyPrefix      string
+	TargetCommands   []string
+	ExcludedCommands []string
+	TargetKeys       []string
+	KeyPrefix        string
+}
+
+func commandInList(command string, commands []string) bool {
+	for _, candidate := range commands {
+		if strings.EqualFold(candidate, command) {
+			return true
+		}
+	}
+	return false
 }
 
 func extractKeyFromPayLoad(redisMessage *RedisMessage) string {
@@ -628,7 +638,8 @@ func (r RedisFilter) Filter(req ParsedMessage, resp ParsedMessage) bool {
 		return false
 	}
 	pass := true
-	pass = pass && (len(r.TargetCommands) == 0 || slices.Index(r.TargetCommands, redisReq.Command()) != -1)
+	pass = pass && (len(r.TargetCommands) == 0 || commandInList(redisReq.Command(), r.TargetCommands))
+	pass = pass && (len(r.ExcludedCommands) == 0 || !commandInList(redisReq.Command(), r.ExcludedCommands))
 	firstKey := extractKeyFromPayLoad(redisReq)
 	pass = pass && (len(r.TargetKeys) == 0 || slices.Index(r.TargetKeys, firstKey) != -1)
 	pass = pass && (r.KeyPrefix == "" || strings.HasPrefix(firstKey, r.KeyPrefix))
@@ -641,7 +652,7 @@ func (r RedisFilter) FilterByProtocol(p bpf.AgentTrafficProtocolT) bool {
 }
 
 func (r RedisFilter) FilterByRequest() bool {
-	return len(r.TargetCommands) > 0 || len(r.TargetKeys) > 0 || r.KeyPrefix != ""
+	return len(r.TargetCommands) > 0 || len(r.ExcludedCommands) > 0 || len(r.TargetKeys) > 0 || r.KeyPrefix != ""
 }
 
 func (r RedisFilter) FilterByResponse() bool {

--- a/agent/protocol/redis_filter_test.go
+++ b/agent/protocol/redis_filter_test.go
@@ -1,0 +1,98 @@
+package protocol
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestRedisFilter_Filter(t *testing.T) {
+	type fields struct {
+		TargetCommands   []string
+		ExcludedCommands []string
+		TargetKeys       []string
+		KeyPrefix        string
+	}
+	type args struct {
+		req ParsedMessage
+	}
+
+	tests := []struct {
+		name   string
+		fields fields
+		args   args
+		want   bool
+	}{
+		{
+			name: "filter_by_target_command",
+			fields: fields{
+				TargetCommands: []string{"GET"},
+			},
+			args: args{
+				req: &RedisMessage{command: "GET", payload: "user:1"},
+			},
+			want: true,
+		},
+		{
+			name: "exclude_command_blocks_match",
+			fields: fields{
+				ExcludedCommands: []string{"INFO", "CLUSTER"},
+			},
+			args: args{
+				req: &RedisMessage{command: "INFO", payload: "stats"},
+			},
+			want: false,
+		},
+		{
+			name: "exclude_command_is_case_insensitive",
+			fields: fields{
+				ExcludedCommands: []string{"info", "cluster"},
+			},
+			args: args{
+				req: &RedisMessage{command: "INFO", payload: "stats"},
+			},
+			want: false,
+		},
+		{
+			name: "exclude_command_does_not_block_other_commands",
+			fields: fields{
+				ExcludedCommands: []string{"INFO", "CLUSTER"},
+			},
+			args: args{
+				req: &RedisMessage{command: "GET", payload: "user:1"},
+			},
+			want: true,
+		},
+		{
+			name: "target_and_excluded_command_prefers_exclusion",
+			fields: fields{
+				TargetCommands:   []string{"INFO"},
+				ExcludedCommands: []string{"INFO"},
+			},
+			args: args{
+				req: &RedisMessage{command: "INFO", payload: "stats"},
+			},
+			want: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			filter := RedisFilter{
+				TargetCommands:   tt.fields.TargetCommands,
+				ExcludedCommands: tt.fields.ExcludedCommands,
+				TargetKeys:       tt.fields.TargetKeys,
+				KeyPrefix:        tt.fields.KeyPrefix,
+			}
+			assert.Equal(t, tt.want, filter.Filter(tt.args.req, nil))
+		})
+	}
+}
+
+func TestRedisFilter_FilterByRequest(t *testing.T) {
+	filter := RedisFilter{
+		ExcludedCommands: []string{"INFO"},
+	}
+
+	assert.True(t, filter.FilterByRequest())
+}

--- a/cmd/redis.go
+++ b/cmd/redis.go
@@ -7,12 +7,16 @@ import (
 )
 
 var redisCmd *cobra.Command = &cobra.Command{
-	Use:   "redis [--command COMMANDS]",
+	Use:   "redis [--command COMMANDS] [--exclude-commands COMMANDS]",
 	Short: "watch Redis message",
 	Run: func(cmd *cobra.Command, args []string) {
 		commands, err := cmd.Flags().GetStringSlice("command")
 		if err != nil {
 			logger.Fatalf("invalid method: %v\n", err)
+		}
+		excludedCommands, err := cmd.Flags().GetStringSlice("exclude-commands")
+		if err != nil {
+			logger.Fatalf("invalid exclude-commands: %v\n", err)
 		}
 		keys, err := cmd.Flags().GetStringSlice("keys")
 		if err != nil {
@@ -24,9 +28,10 @@ var redisCmd *cobra.Command = &cobra.Command{
 		}
 
 		options.MessageFilter = protocol.RedisFilter{
-			TargetCommands: commands,
-			TargetKeys:     keys,
-			KeyPrefix:      prefix,
+			TargetCommands:   commands,
+			ExcludedCommands: excludedCommands,
+			TargetKeys:       keys,
+			KeyPrefix:        prefix,
 		}
 		options.LatencyFilter = initLatencyFilter(cmd)
 		options.SizeFilter = initSizeFilter(cmd)
@@ -36,6 +41,7 @@ var redisCmd *cobra.Command = &cobra.Command{
 
 func init() {
 	redisCmd.Flags().StringSlice("command", []string{}, "Specify the redis command to monitor(GET, SET), seperate by ','")
+	redisCmd.Flags().StringSlice("exclude-commands", []string{}, "Specify redis commands to exclude(INFO, CLUSTER), seperate by ','")
 	redisCmd.Flags().StringSlice("keys", []string{}, "Specify the redis keys to monitor, seperate by ','")
 	redisCmd.Flags().String("key-prefix", "", "Specify the redis key prefix to monitor")
 	redisCmd.Flags().SortFlags = false


### PR DESCRIPTION
## Problem
Redis filtering currently supports positive command matching, key matching, and key-prefix matching, but there is no way to exclude noisy commands like `INFO` or `CLUSTER`.

## What changed
- added an `--exclude-commands` flag to the `redis` command
- extended `protocol.RedisFilter` with `ExcludedCommands`
- made command matching case-insensitive so values like `info,cluster` work as expected
- added Redis filter tests covering excluded commands, lowercase exclusions, and the interaction between include/exclude rules

## Why this fixes it
This keeps the behavior in the existing Redis filter path and lets excluded commands short-circuit the match before records are emitted.

## Verification
- `GOOS=linux GOARCH=arm64 go test -c ./agent/protocol`

I could not run the full Kyanos test suite on this macOS machine because the repo depends on Linux-only code and BPF tooling for end-to-end execution.

Fixes #265