### PR TITLE
fix(cmd): correct typo "seperate" → "separate" in flag help text

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -60,11 +60,11 @@ var ContainerName string
 var PodName string
 
 func init() {
-	rootCmd.PersistentFlags().StringSliceVarP(&FilterPids, "pids", "p", []string{}, "Filter by pids, seperate by ','")
+	rootCmd.PersistentFlags().StringSliceVarP(&FilterPids, "pids", "p", []string{}, "Filter by pids, separate by ','")
 	rootCmd.PersistentFlags().StringVar(&options.FilterComm, "comm", "", "Filter by process name")
-	rootCmd.PersistentFlags().StringSliceVarP(&RemotePorts, common.RemotePortsVarName, "", []string{}, "Filter by remote ports, seperate by ','")
-	rootCmd.PersistentFlags().StringSliceVarP(&LocalPorts, common.LocalPortsVarName, "", []string{}, "Filter by local ports, seperate by ','")
-	rootCmd.PersistentFlags().StringSliceVarP(&RemoteIps, common.RemoteIpsVarName, "", []string{}, "Filter by remote ips, seperate by ','")
+	rootCmd.PersistentFlags().StringSliceVarP(&RemotePorts, common.RemotePortsVarName, "", []string{}, "Filter by remote ports, separate by ','")
+	rootCmd.PersistentFlags().StringSliceVarP(&LocalPorts, common.LocalPortsVarName, "", []string{}, "Filter by local ports, separate by ','")
+	rootCmd.PersistentFlags().StringSliceVarP(&RemoteIps, common.RemoteIpsVarName, "", []string{}, "Filter by remote ips, separate by ','")
 	// rootCmd.PersistentFlags().StringVar(&IfName, "ifname", "eth0", "--ifname eth0")
 	rootCmd.PersistentFlags().StringVar(&BTFFilePath, "btf", "", "specify kernel BTF file")
 


### PR DESCRIPTION
## Summary

Fixes a 4x typo in the `--pids`, `--remote-ports`, `--local-ports`, and `--remote-ips` flag help text in `cmd/root.go`. The text \"seperate by ','\" should be \"separate by ','\". This text is user-visible — it appears in the output of `kyanos --help`.

No behavior change. Comment/help-text only fix.

## Verification

```
$ git diff --stat
 cmd/root.go | 8 ++++----
 1 file changed, 4 insertions(+), 4 deletions(-)
```