### PR TITLE
fix(kafka): honor topic direction filters

### DIFF
--- a/agent/conn/record_processor_kafka_test.go
+++ b/agent/conn/record_processor_kafka_test.go
@@ -1,0 +1,71 @@
+package conn
+
+import (
+	"testing"
+
+	"kyanos/agent/protocol"
+	"kyanos/agent/protocol/kafka"
+	kcommon "kyanos/agent/protocol/kafka/common"
+	"kyanos/bpf"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestSubmitRecord_KafkaConsumerTopicFilterSubmitsMatchingFetch(t *testing.T) {
+	oldRecordFunc := RecordFunc
+	defer func() { RecordFunc = oldRecordFunc }()
+
+	submitted := false
+	RecordFunc = func(record protocol.Record, c *Connection4) error {
+		submitted = true
+		return nil
+	}
+
+	conn := &Connection4{
+		Protocol:        bpf.AgentTrafficProtocolTKProtocolKafka,
+		protocolParsers: make(map[bpf.AgentTrafficProtocolT]protocol.ProtocolStreamParser),
+		MessageFilter:   kafka.NewKafkaFilter(nil, "orders", false, true),
+	}
+	record := protocol.NewRecord(
+		&kcommon.Request{Apikey: kcommon.KFetch},
+		&kcommon.Response{
+			OriginResp: kcommon.FetchResp{
+				Topics: []kcommon.FetchRespTopic{{Name: "orders"}},
+			},
+		},
+	)
+
+	submitRecord(*record, conn)
+
+	assert.True(t, submitted)
+}
+
+func TestSubmitRecord_KafkaTopicFilterRejectsWhenNoDirectionEnabled(t *testing.T) {
+	oldRecordFunc := RecordFunc
+	defer func() { RecordFunc = oldRecordFunc }()
+
+	submitted := false
+	RecordFunc = func(record protocol.Record, c *Connection4) error {
+		submitted = true
+		return nil
+	}
+
+	conn := &Connection4{
+		Protocol:        bpf.AgentTrafficProtocolTKProtocolKafka,
+		protocolParsers: make(map[bpf.AgentTrafficProtocolT]protocol.ProtocolStreamParser),
+		MessageFilter:   kafka.NewKafkaFilter(nil, "orders", false, false),
+	}
+	record := protocol.NewRecord(
+		&kcommon.Request{
+			Apikey: kcommon.KProduce,
+			OriginReq: kcommon.ProduceReq{
+				Topics: []kcommon.ProduceReqTopic{{Name: "orders"}},
+			},
+		},
+		&kcommon.Response{},
+	)
+
+	submitRecord(*record, conn)
+
+	assert.False(t, submitted)
+}

--- a/agent/protocol/kafka/filter.go
+++ b/agent/protocol/kafka/filter.go
@@ -28,54 +28,45 @@ func NewKafkaFilter(apiKey []int32, topic string, producer bool, consumer bool) 
 }
 
 func (k *KafkaFilter) Filter(req protocol.ParsedMessage, resp protocol.ParsedMessage) bool {
-	pass := true
-	pass = pass && (len(k.apiKey) == 0 || containsAPIKey(k.apiKey, req.(*Request).Apikey))
-	if k.topic != "" && pass {
-		kafkaReq, ok := req.(*Request)
-		if !ok {
+	kafkaReq, ok := req.(*Request)
+	if !ok {
+		return false
+	}
+	if len(k.apiKey) > 0 && !containsAPIKey(k.apiKey, kafkaReq.Apikey) {
+		return false
+	}
+	if k.topic == "" {
+		return true
+	}
+	if kafkaReq.Apikey == KProduce {
+		if !k.producer || kafkaReq.OriginReq == nil {
 			return false
 		}
-		if kafkaReq.Apikey == KProduce {
-			if k.producer && kafkaReq.OriginReq != nil {
-				originProduceReq := kafkaReq.OriginReq.(ProduceReq)
-				matched := false
-				for _, topic := range originProduceReq.Topics {
-					if topic.Name == k.topic {
-						matched = true
-						break
-					}
-				}
-				if len(originProduceReq.Topics) == 0 || !matched {
-					pass = false
-				}
-			} else {
-				pass = false
+		originProduceReq := kafkaReq.OriginReq.(ProduceReq)
+		for _, topic := range originProduceReq.Topics {
+			if topic.Name == k.topic {
+				return true
 			}
-		} else if kafkaReq.Apikey == KFetch {
-			kafkaResp, ok := resp.(*Response)
-			if !ok {
-				return false
-			}
-			if k.consumer && kafkaResp.OriginResp != nil {
-				originFetchResp := kafkaResp.OriginResp.(FetchResp)
-				matched := false
-				for _, topic := range originFetchResp.Topics {
-					if topic.Name == k.topic {
-						matched = true
-						break
-					}
-				}
-				if len(originFetchResp.Topics) == 0 || !matched {
-					pass = false
-				}
-			} else {
-				pass = false
-			}
-		} else {
-			pass = false
 		}
+		return false
 	}
-	return pass
+	if kafkaReq.Apikey == KFetch {
+		if !k.consumer {
+			return false
+		}
+		kafkaResp, ok := resp.(*Response)
+		if !ok || kafkaResp.OriginResp == nil {
+			return false
+		}
+		originFetchResp := kafkaResp.OriginResp.(FetchResp)
+		for _, topic := range originFetchResp.Topics {
+			if topic.Name == k.topic {
+				return true
+			}
+		}
+		return false
+	}
+	return false
 }
 
 func containsAPIKey(apiKeys []APIKey, key APIKey) bool {
@@ -92,11 +83,11 @@ func (k *KafkaFilter) FilterByProtocol(p bpf.AgentTrafficProtocolT) bool {
 }
 
 func (k *KafkaFilter) FilterByRequest() bool {
-	return len(k.apiKey) == 0 || (k.producer && k.topic != "")
+	return len(k.apiKey) > 0 || k.topic != ""
 }
 
 func (k *KafkaFilter) FilterByResponse() bool {
-	return (k.consumer && k.topic != "")
+	return k.consumer && k.topic != ""
 }
 
 func (KafkaFilter) Protocol() bpf.AgentTrafficProtocolT {


### PR DESCRIPTION
## Summary
Kafka `--topic` filtering was a bit wonky.

Before this patch:
- `--topic orders --producer=false --consumer=true` could miss matching fetch traffic
- `--topic orders --producer=false --consumer=false` could still let records through

## Repro
1. Start Kafka traffic for topic `orders`
2. Run `sudo kyanos watch kafka --topic orders --producer=false --consumer=true`
3. Before this patch, matching fetch records can be skipped, because the filter only gets the response and loses the request api key
4. Run `sudo kyanos watch kafka --topic orders --producer=false --consumer=false`
5. Before this patch, records can still pass because `submitRecord()` falls back to `needSubmit=true` when neither side is requested

## Fix
Always pass the Kafka request into topic filtering, and only require the response when consumer topic matching needs it. Added regression tests too.

## Checks
- `go test ./agent/conn ./agent/protocol/kafka`

Related history: #174, #267, #271
