### PR TITLE
fix: support OpenSSL 3.6.x

### DIFF
--- a/agent/uprobe/ssl_test.go
+++ b/agent/uprobe/ssl_test.go
@@ -7,6 +7,16 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
+func TestOpenSSL36VersionsAreMapped(t *testing.T) {
+	for _, versionKey := range []string{
+		"openssl 3.6.0",
+		"openssl 3.6.1",
+		"openssl 3.6.2",
+	} {
+		assert.NotNil(t, sslVersionBpfMap[versionKey], versionKey)
+	}
+}
+
 func TestDetectOpenSsl(t *testing.T) {
 	key, err := detectOpenSsl(2276284)
 	assert.Nil(t, err)

--- a/agent/uprobe/types.go
+++ b/agent/uprobe/types.go
@@ -90,6 +90,7 @@ const (
 	MaxSupportedOpenSSL33Version  = 2
 	SupportedOpenSSL34Version0    = 1 // openssl 3.4.0
 	SupportedOpenSSL35Version0    = 5 // openssl 3.5.0 ~ 3.5.5
+	SupportedOpenSSL36Version0    = 2 // openssl 3.6.0 ~ 3.6.2
 )
 const (
 	Linuxdefaulefilename102 = "linux_default_1_0_2"
@@ -325,9 +326,21 @@ func initOpensslOffset() {
 		}
 	}
 
-	// openssl 3.5.0
+	// openssl 3.5.0 - 3.5.5
 	for ch := 0; ch <= SupportedOpenSSL35Version0; ch++ {
 		sslVersionBpfMap[fmt.Sprintf("openssl 3.5.%d", ch)] = func() (*ebpf.CollectionSpec, any, error) {
+			r, err := bpf.LoadOpenssl350()
+			if err != nil {
+				common.UprobeLog.Errorln(err)
+				return nil, nil, err
+			}
+			return r, &bpf.Openssl350Objects{}, nil
+		}
+	}
+
+	// openssl 3.6.0 - 3.6.2
+	for ch := 0; ch <= SupportedOpenSSL36Version0; ch++ {
+		sslVersionBpfMap[fmt.Sprintf("openssl 3.6.%d", ch)] = func() (*ebpf.CollectionSpec, any, error) {
 			r, err := bpf.LoadOpenssl350()
 			if err != nil {
 				common.UprobeLog.Errorln(err)


### PR DESCRIPTION
## Summary
- add OpenSSL 3.6.0-3.6.2 entries to the SSL BPF loader map
- reuse the existing OpenSSL 3.5 offset loader for the 3.6.x series
- add a regression test covering the 3.6.x version keys

## Validation
- `go test ./agent/uprobe -run TestOpenSSL36VersionsAreMapped -count=1`
- `make`
- local HTTPS repro with a process reporting `OpenSSL 3.6.2`: missing bpfFunc warnings dropped to 0 and decrypted `httpbin` plaintext appeared in the watch log
