### PR TITLE
[codex] skip test workflow for renovate

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,6 +16,7 @@ permissions:
 jobs:
 
   build:
+    if: ${{ github.actor != 'renovate[bot]' && !startsWith(github.head_ref, 'renovate/') && !startsWith(github.ref_name, 'renovate/') }}
     runs-on: ubuntu-22.04
     timeout-minutes: 60
     steps:
@@ -57,6 +58,7 @@ jobs:
 
   e2e-test:
     name: e2e-test
+    if: ${{ github.actor != 'renovate[bot]' && !startsWith(github.head_ref, 'renovate/') && !startsWith(github.ref_name, 'renovate/') }}
     needs: build
     strategy:
       fail-fast: false


### PR DESCRIPTION
## Summary

- skip the Test workflow jobs when the actor is `renovate[bot]`
- also skip jobs for `renovate/*` head refs or pushed branch names

## Why

Renovate dependency update PRs should not spend CI capacity on the heavy Test workflow. GitHub Actions cannot filter pull request head branches with `pull_request.branches-ignore`, so the skip is applied at the job level.

## Validation

- `git diff --check`
