### PR TITLE
docs: fix broken star history chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,6 +228,6 @@ For more detailed inquiries, you can use the following contact methods:
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=hengyoush/kyanos&type=Date)](https://star-history.com/#hengyoush/kyanos&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=hengyoush/kyanos&type=Date)](https://star-history.dera.page/#hengyoush/kyanos&Date)
 
 [Back to top](#top)

--- a/README_CN.md
+++ b/README_CN.md
@@ -196,6 +196,6 @@ sudo ./kyanos watch
 
 ## Star History
 
-[![Star History Chart](https://api.star-history.com/svg?repos=hengyoush/kyanos&type=Date)](https://star-history.com/#hengyoush/kyanos&Date)
+[![Star History Chart](https://star-history.dera.page/svg?repos=hengyoush/kyanos&type=Date)](https://star-history.dera.page/#hengyoush/kyanos&Date)
 
 [Back to top](#top)


### PR DESCRIPTION
The star history chart displayed in the README and README_CN is currently broken because of the GitHub stargazer API restrictions. This change switches the chart to a working provider so it renders correctly again.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated Star History chart links in the English and Chinese README files.
  * Charts now use the new `star-history.dera.page` address.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->